### PR TITLE
Switch worker to HTTP API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # Hashmancer
 
 This project hosts the server side code as well as a lightweight worker
-implementation.  The server exposes a FastAPI application and uses Redis to
-queue hash cracking jobs.  Workers register their GPUs with Redis and consume
-jobs from a Redis stream.
+implementation. The server exposes a FastAPI application backed by Redis. The
+worker communicates with the server over HTTP, caching batches in its local
+Redis instance for fast GPU access. Heartbeat updates can be tuned with the
+`STATUS_INTERVAL` environment variable.
 
 * `Server/` – FastAPI server and orchestration tools
-* `Worker/` – basic Redis worker with GPU sidecar threads
+* `Worker/` – HTTP-based worker with GPU sidecar threads

--- a/Worker/README.md
+++ b/Worker/README.md
@@ -1,16 +1,19 @@
 # Hashmancer Worker
 
-This directory contains a minimal Redis based worker implementation for the Hashmancer project.
-Workers register their GPUs with Redis, consume jobs from a stream and update job status when
-processing completes. Each GPU is handled by a lightweight sidecar thread.
+This directory contains a lightweight worker that communicates with the server
+over its HTTP API. Jobs are cached in a local Redis instance and for GPUs on
+x1/x4 PCIe links a copy of the payload is stored in VRAM so hashcat loads data
+faster.
 
 ## Components
 
-- `hashmancer_worker/worker_agent.py` – registers the worker and spawns GPU sidecars
-- `hashmancer_worker/gpu_sidecar.py` – reads jobs from a Redis stream and simulates GPU work
+- `hashmancer_worker/worker_agent.py` – registers with `/register_worker` and spawns GPU sidecars
+- `hashmancer_worker/gpu_sidecar.py` – fetches batches via `/get_batch` and submits results
 
-The worker expects a running Redis instance which can be configured through the environment
-variables `REDIS_HOST`, `REDIS_PORT` and `JOBS_STREAM`.
+The worker expects a local Redis instance for caching. Configure `REDIS_HOST` and
+`REDIS_PORT`. Point to the server with `SERVER_URL` and provide signing keys via
+`PRIVATE_KEY_PATH` and `PUBLIC_KEY_PATH`. The status heartbeat interval can be
+customized with `STATUS_INTERVAL` (seconds).
 
 Start a worker with:
 
@@ -18,5 +21,5 @@ Start a worker with:
 python -m hashmancer_worker.worker_agent
 ```
 
-The example implementation only simulates work but demonstrates how GPU registration and
-stream consumption operate in the new architecture.
+The example implementation only simulates work but demonstrates how GPU registration,
+HTTP batch retrieval and result submission operate in the new architecture.

--- a/Worker/hashmancer_worker/crypto_utils.py
+++ b/Worker/hashmancer_worker/crypto_utils.py
@@ -1,0 +1,24 @@
+import os
+import base64
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding
+
+PRIVATE_KEY_PATH = os.getenv("PRIVATE_KEY_PATH", "./worker_private_key.pem")
+PUBLIC_KEY_PATH = os.getenv("PUBLIC_KEY_PATH", "./worker_public_key.pem")
+
+
+def load_private_key():
+    with open(PRIVATE_KEY_PATH, "rb") as f:
+        key_data = f.read()
+    return serialization.load_pem_private_key(key_data, password=None)
+
+
+def load_public_key_pem() -> str:
+    with open(PUBLIC_KEY_PATH, "r") as f:
+        return f.read()
+
+
+def sign_message(message: str) -> str:
+    key = load_private_key()
+    signature = key.sign(message.encode(), padding.PKCS1v15(), hashes.SHA256())
+    return base64.b64encode(signature).decode()

--- a/Worker/hashmancer_worker/worker_agent.py
+++ b/Worker/hashmancer_worker/worker_agent.py
@@ -1,41 +1,43 @@
 import os
 import json
-import socket
 import subprocess
 import time
 import uuid
-import threading
 import redis
+import requests
 
 from .gpu_sidecar import GPUSidecar
+from .crypto_utils import load_public_key_pem
 
 REDIS_HOST = os.getenv("REDIS_HOST", "localhost")
 REDIS_PORT = int(os.getenv("REDIS_PORT", "6379"))
-STREAM = os.getenv("JOBS_STREAM", "jobs")
+SERVER_URL = os.getenv("SERVER_URL", "http://localhost:8000")
+STATUS_INTERVAL = int(os.getenv("STATUS_INTERVAL", "30"))
 
 r = redis.Redis(host=REDIS_HOST, port=REDIS_PORT, decode_responses=True)
 
 
 def detect_gpus() -> list[dict]:
-    """Return a list of GPUs with uuid, model, pci_bus, memory_mb."""
+    """Return a list of GPUs with basic specs."""
     try:
         output = subprocess.check_output(
             [
                 "nvidia-smi",
-                "--query-gpu=index,uuid,name,pci.bus_id,memory.total",
+                "--query-gpu=index,uuid,name,pci.bus_id,pci.link.width.max,memory.total",
                 "--format=csv,noheader",
             ],
             text=True,
         )
         gpus = []
         for line in output.strip().splitlines():
-            idx, uuid_str, name, bus, mem = [x.strip() for x in line.split(',')]
+            idx, uuid_str, name, bus, width, mem = [x.strip() for x in line.split(',')]
             gpus.append(
                 {
                     "index": int(idx),
                     "uuid": uuid_str,
                     "model": name,
                     "pci_bus": bus,
+                    "pci_width": int(width),
                     "memory_mb": int(mem.split()[0]),
                 }
             )
@@ -48,49 +50,45 @@ def detect_gpus() -> list[dict]:
                 "uuid": str(uuid.uuid4()),
                 "model": "CPU",  # placeholder
                 "pci_bus": "0000:00:00.0",
+                "pci_width": 16,
                 "memory_mb": 0,
             }
         ]
 
 
-def register_worker(worker_id: str, gpus: list[dict]):
-    ip = socket.gethostbyname(socket.gethostname())
-    ts = int(time.time())
-    r.hset(
-        f"worker:{worker_id}",
-        mapping={"ip": ip, "status": "idle", "last_seen": ts},
-    )
-    r.sadd("workers", worker_id)
-    for g in gpus:
-        r.hset(
-            f"gpu:{g['uuid']}",
-            mapping={
-                "model": g["model"],
-                "pci_bus": g["pci_bus"],
-                "memory_mb": g["memory_mb"],
-                "worker": worker_id,
-            },
-        )
-        r.sadd(f"worker:{worker_id}:gpus", g["uuid"])
+def register_worker(worker_id: str, gpus: list[dict]) -> str:
+    """Register with the server and return the assigned name."""
+    payload = {
+        "worker_id": worker_id,
+        "hardware": {"gpus": gpus},
+    }
+    try:
+        payload["pubkey"] = load_public_key_pem()
+    except FileNotFoundError:
+        payload["pubkey"] = ""
+    resp = requests.post(f"{SERVER_URL}/register_worker", json=payload, timeout=10)
+    resp.raise_for_status()
+    data = resp.json()
+    name = data.get("waifu", worker_id)
+    return name
 
 
 def main():
     worker_id = os.getenv("WORKER_ID", str(uuid.uuid4()))
     gpus = detect_gpus()
-    register_worker(worker_id, gpus)
-    try:
-        r.xgroup_create(STREAM, worker_id, id='$', mkstream=True)
-    except redis.exceptions.ResponseError as e:
-        if "BUSYGROUP" not in str(e):
-            raise
-    threads = [GPUSidecar(worker_id, gpu) for gpu in gpus]
+    name = register_worker(worker_id, gpus)
+    threads = [GPUSidecar(name, gpu, SERVER_URL) for gpu in gpus]
     for t in threads:
         t.start()
-    print(f"Worker {worker_id} started with {len(gpus)} GPUs")
+    print(f"Worker {name} started with {len(gpus)} GPUs")
     try:
         while True:
-            r.hset(f"worker:{worker_id}", "last_seen", int(time.time()))
-            time.sleep(10)
+            requests.post(
+                f"{SERVER_URL}/worker_status",
+                json={"name": name, "status": "online"},
+                timeout=5,
+            )
+            time.sleep(STATUS_INTERVAL)
     except KeyboardInterrupt:
         print("Stopping worker...")
         for t in threads:


### PR DESCRIPTION
## Summary
- add crypto utils module for signing worker API requests
- rework worker_agent to register and communicate with server over HTTP
- rework gpu_sidecar to fetch jobs via HTTP and submit results
- update Worker docs to describe HTTP workflow
- update project README accordingly
- add heartbeat interval and submit_no_founds handling

## Testing
- `python -m py_compile Worker/hashmancer_worker/*.py Server/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6877ae8a7a408326aa031c58e53114ad