### PR TITLE
Handle request errors for hashes.com client

### DIFF
--- a/Server/hashescom_client.py
+++ b/Server/hashescom_client.py
@@ -10,10 +10,14 @@ def fetch_jobs():
         if HASHES_API:
             url += f"?key={HASHES_API}"
         resp = requests.get(url, timeout=10)
+        resp.raise_for_status()
         data = resp.json()
         if not data.get("success"):
             return []
         return data["list"]
+    except requests.HTTPError as e:
+        print(f"[❌] Hashes.com fetch error: {e}")
+        return []
     except Exception as e:
         print(f"[❌] Hashes.com fetch error: {e}")
         return []
@@ -25,7 +29,11 @@ def upload_founds(algo_id, found_file):
         files = {"userfile": open(found_file, "rb")}
         data = {"algo": str(algo_id), "key": HASHES_API or ""}
         resp = requests.post(url, files=files, data=data, timeout=10)
+        resp.raise_for_status()
         return resp.json()
+    except requests.HTTPError as e:
+        print(f"[❌] Upload error: {e}")
+        return {}
     except Exception as e:
         print(f"[❌] Upload error: {e}")
         return {}


### PR DESCRIPTION
## Summary
- raise for HTTP failures in `hashescom_client`
- log `requests.HTTPError` separately before returning

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877f1e288b08326bb47af986d1dcae0