### PR TITLE
Require Hashes.com API key for setup

### DIFF
--- a/Server/README.md
+++ b/Server/README.md
@@ -59,7 +59,7 @@ python3 setup.py
 ```
 
 This will:
-- Prompt for base directories for wordlists, masks, and rules along with your API key
+- Prompt for base directories for wordlists, masks, and rules. A Hashes.com API key is required for registration
 - Configure Redis and logging
 - Install a systemd service
 - Optionally enable a UDP broadcast so workers can auto-discover the server

--- a/Server/setup.py
+++ b/Server/setup.py
@@ -72,6 +72,9 @@ def configure():
     print("🔧 Hashmancer Server Setup")
 
     api_key = prompt("Enter your hashes.com API key", secret=True)
+    if not api_key:
+        print("❌ Hashes.com API key is required for registration. Aborting.")
+        return
     public_url = prompt(
         "Public URL for cloud workers (leave blank for private/local only)", ""
     )


### PR DESCRIPTION
## Summary
- validate Hashes.com API key during server setup
- note the API key requirement in documentation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6877f395e7048326bdfc2e59aec57fc3