### PR TITLE
Verify signatures on worker endpoints

### DIFF
--- a/Server/README.md
+++ b/Server/README.md
@@ -105,7 +105,7 @@ specific worker so you can keep an eye on performance over time.
 
 | Method | Path                | Description                         |
 |--------|---------------------|-------------------------------------|
-| POST   | `/register_worker`  | Register a new worker               |
+| POST   | `/register_worker`  | Register a new worker (optional signature) |
 | GET    | `/get_batch`        | Worker requests a batch             |
 | POST   | `/submit_founds`    | Submit cracked hashes               |
 | POST   | `/submit_no_founds` | Report a finished batch with none   |
@@ -114,6 +114,7 @@ specific worker so you can keep an eye on performance over time.
 | GET    | `/rules`            | List available hashcat rules        |
 | GET    | `/workers`          | List registered workers             |
 | GET    | `/hashrate`         | Aggregate hashrate of all workers   |
+| POST   | `/worker_status`    | Update a worker's status (optional signature) |
 
 ---
 


### PR DESCRIPTION
## Summary
- verify optional `signature` on `/register_worker`
- verify optional `signature` on `/worker_status`
- document new optional signatures in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6877fbf9d4108326bc659b30d127b399