### PR TITLE
Add unified setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,7 @@ GPU specs include a `pci_link_width` field for bandwidth-aware scheduling.
 
 * `Server/` – FastAPI server and orchestration tools
 * `Worker/` – HTTP-based worker with GPU sidecar threads
+
+Run `python3 setup.py` from the repository root to configure either a server or
+worker.  Use `--server` or `--worker` flags to skip the prompt.  A worker can
+also supply `--server-ip` to skip auto-discovery.

--- a/Server/README.md
+++ b/Server/README.md
@@ -53,10 +53,10 @@ git clone https://github.com/infernal-Insights/hashmancer-server.git
 cd hashmancer-server
 ```
 
-2. Run the interactive setup script:
+2. Run the interactive setup script from the repository root:
 
 ```bash
-python3 setup.py
+python3 ../setup.py --server
 ```
 
 This will:

--- a/Worker/README.md
+++ b/Worker/README.md
@@ -15,6 +15,10 @@ The worker expects a local Redis instance for caching. Configure `REDIS_HOST` an
 `PRIVATE_KEY_PATH` and `PUBLIC_KEY_PATH`. The status heartbeat interval can be
 customized with `STATUS_INTERVAL` (seconds).
 
+Run `python3 ../setup.py --worker` from the repository root to install
+dependencies and configure the worker.  Passing `--server-ip` skips broadcast
+discovery.
+
 Start a worker with:
 
 ```bash

--- a/Worker/hashmancer_worker/worker_agent.py
+++ b/Worker/hashmancer_worker/worker_agent.py
@@ -5,6 +5,7 @@ import time
 import uuid
 import redis
 import requests
+from pathlib import Path
 
 from .gpu_sidecar import GPUSidecar
 from .crypto_utils import load_public_key_pem
@@ -13,6 +14,17 @@ REDIS_HOST = os.getenv("REDIS_HOST", "localhost")
 REDIS_PORT = int(os.getenv("REDIS_PORT", "6379"))
 SERVER_URL = os.getenv("SERVER_URL", "http://localhost:8000")
 STATUS_INTERVAL = int(os.getenv("STATUS_INTERVAL", "30"))
+
+CONFIG_FILE = Path.home() / ".hashmancer" / "worker_config.json"
+if CONFIG_FILE.exists():
+    try:
+        with open(CONFIG_FILE) as f:
+            cfg = json.load(f)
+        SERVER_URL = os.getenv("SERVER_URL", cfg.get("server_url", SERVER_URL))
+        REDIS_HOST = os.getenv("REDIS_HOST", cfg.get("redis_host", REDIS_HOST))
+        REDIS_PORT = int(os.getenv("REDIS_PORT", cfg.get("redis_port", REDIS_PORT)))
+    except Exception:
+        pass
 
 r = redis.Redis(host=REDIS_HOST, port=REDIS_PORT, decode_responses=True)
 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,86 @@
+import argparse
+import json
+import subprocess
+import socket
+import os
+from pathlib import Path
+
+CONFIG_DIR = Path.home() / ".hashmancer"
+CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+WORKER_CONFIG = CONFIG_DIR / "worker_config.json"
+
+
+def discover_server(timeout: int = 5, port: int = 50000) -> str | None:
+    """Listen for a UDP broadcast announcing the server URL."""
+    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        s.bind(("", port))
+        s.settimeout(timeout)
+        try:
+            data, _ = s.recvfrom(1024)
+            info = json.loads(data.decode())
+            return info.get("server_url")
+        except Exception:
+            return None
+
+
+def run_server_setup():
+    import Server.setup as srv_setup
+
+    srv_setup.install_dependencies()
+    srv_setup.configure()
+
+
+def worker_install_deps():
+    print("📦 Installing worker dependencies...")
+    subprocess.run(["pip3", "install", "-r", "Worker/requirements.txt"], check=False)
+    subprocess.run(["sudo", "apt", "install", "-y", "redis-server", "hashcat"], check=False)
+
+
+def worker_configure(server_url: str):
+    cfg = {"server_url": server_url}
+    with open(WORKER_CONFIG, "w") as f:
+        json.dump(cfg, f, indent=2)
+    print("Worker configured for server:", server_url)
+    print("Config saved to", WORKER_CONFIG)
+    print("Run 'python -m hashmancer_worker.worker_agent' to start the worker")
+
+
+def run_worker_setup(server_ip: str | None):
+    worker_install_deps()
+    server_url = None
+    if server_ip:
+        if server_ip.startswith("http"):
+            server_url = server_ip
+        else:
+            server_url = f"http://{server_ip}:8000"
+    else:
+        print("🔎 Listening for server broadcast...")
+        server_url = discover_server()
+        if not server_url:
+            server_url = input("Server URL (e.g. http://1.2.3.4:8000): ").strip()
+    worker_configure(server_url)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Hashmancer setup")
+    parser.add_argument("--server", action="store_true", help="setup a server")
+    parser.add_argument("--worker", action="store_true", help="setup a worker")
+    parser.add_argument("--server-ip", help="server IP or URL for worker setup")
+    args = parser.parse_args()
+
+    if not args.server and not args.worker:
+        choice = input("Configure this machine as [server/worker]?: ").strip().lower()
+        if choice.startswith("s"):
+            args.server = True
+        else:
+            args.worker = True
+
+    if args.server:
+        run_server_setup()
+    else:
+        run_worker_setup(args.server_ip)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement root `setup.py` that runs server or worker setup
- allow automatic worker configuration via broadcast or `--server-ip`
- load `worker_config.json` in `worker_agent.py`
- document the new setup process in `README.md` and submodule READMEs

## Testing
- `python3 -m py_compile setup.py Worker/hashmancer_worker/worker_agent.py`
- `pytest` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68790ce07ba48326b43911a15ce351ea