### PR TITLE
Add configurable Redis and graceful failures

### DIFF
--- a/Server/auth_utils.py
+++ b/Server/auth_utils.py
@@ -1,11 +1,12 @@
 import base64
 import redis
+from redis_utils import get_redis
 import logging
 from cryptography.hazmat.primitives.asymmetric import padding
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.exceptions import InvalidSignature
 
-r = redis.Redis(host="localhost", port=6379, decode_responses=True)
+r = get_redis()
 
 
 def get_worker_pubkey(worker_id):

--- a/Server/orchestrator_agent.py
+++ b/Server/orchestrator_agent.py
@@ -4,60 +4,68 @@ import logging
 import time
 import uuid
 import redis
+from redis_utils import get_redis
 
 JOB_STREAM = os.getenv("JOB_STREAM", "jobs")
 
-r = redis.Redis(host="localhost", port=6379, decode_responses=True)
+r = get_redis()
 
 
 def worker_counts():
     """Return (high_bw, low_bw) worker counts based on stored specs."""
     high = low = 0
-    for key in r.scan_iter("worker:*"):
-        info = r.hgetall(key)
-        specs_json = info.get("specs")
-        if not specs_json:
-            continue
-        try:
-            specs = json.loads(specs_json)
-            if isinstance(specs, dict) and "gpus" in specs:
-                specs = specs["gpus"]
-        except json.JSONDecodeError:
-            specs = []
-        if any(g.get("pci_link_width", 0) >= 8 for g in specs):
-            high += 1
-        else:
-            low += 1
+    try:
+        for key in r.scan_iter("worker:*"):
+            info = r.hgetall(key)
+            specs_json = info.get("specs")
+            if not specs_json:
+                continue
+            try:
+                specs = json.loads(specs_json)
+                if isinstance(specs, dict) and "gpus" in specs:
+                    specs = specs["gpus"]
+            except json.JSONDecodeError:
+                specs = []
+            if any(g.get("pci_link_width", 0) >= 8 for g in specs):
+                high += 1
+            else:
+                low += 1
+    except redis.exceptions.RedisError as e:
+        logging.error(f"Redis unavailable: {e}")
+        return 0, 0
     return high, low
 
 
 def dispatch_batches():
-    batch_id = r.rpop("batch:queue")
-    if not batch_id:
-        return
-    batch = r.hgetall(f"batch:{batch_id}")
-    if not batch:
-        return
+    try:
+        batch_id = r.rpop("batch:queue")
+        if not batch_id:
+            return
+        batch = r.hgetall(f"batch:{batch_id}")
+        if not batch:
+            return
 
-    attack = "mask"
-    if batch.get("wordlist") and batch.get("mask"):
-        attack = "hybrid"
-    elif batch.get("wordlist"):
-        attack = "dict"
+        attack = "mask"
+        if batch.get("wordlist") and batch.get("mask"):
+            attack = "hybrid"
+        elif batch.get("wordlist"):
+            attack = "dict"
 
-    task_id = str(uuid.uuid4())
-    r.hset(
-        f"job:{task_id}",
-        mapping={
-            "hashes": batch.get("hashes", "[]"),
-            "mask": batch.get("mask", ""),
-            "wordlist": batch.get("wordlist", ""),
-            "attack_mode": attack,
-            "status": "queued",
-        },
-    )
-    r.expire(f"job:{task_id}", 3600)
-    r.xadd(JOB_STREAM, {"job_id": task_id})
+        task_id = str(uuid.uuid4())
+        r.hset(
+            f"job:{task_id}",
+            mapping={
+                "hashes": batch.get("hashes", "[]"),
+                "mask": batch.get("mask", ""),
+                "wordlist": batch.get("wordlist", ""),
+                "attack_mode": attack,
+                "status": "queued",
+            },
+        )
+        r.expire(f"job:{task_id}", 3600)
+        r.xadd(JOB_STREAM, {"job_id": task_id})
+    except redis.exceptions.RedisError as e:
+        logging.error(f"Redis unavailable: {e}")
 
 
 if __name__ == "__main__":

--- a/Server/redis_manager.py
+++ b/Server/redis_manager.py
@@ -1,37 +1,49 @@
 import redis
+from redis_utils import get_redis
 import json
 import uuid
 import time
 
-r = redis.Redis(host="localhost", port=6379, decode_responses=True)
+r = get_redis()
 
 
 def store_batch(hashes, mask="", wordlist="", ttl=1800, target="any"):
     batch_id = str(uuid.uuid4())
-    r.hset(
-        f"batch:{batch_id}",
-        mapping={
-            "hashes": json.dumps(hashes),
-            "mask": mask,
-            "wordlist": wordlist,
-            "created": int(time.time()),
-            "target": json.dumps(target),
-            "status": "queued",
-        },
-    )
-    r.expire(f"batch:{batch_id}", ttl)
-    r.lpush("batch:queue", batch_id)
+    try:
+        r.hset(
+            f"batch:{batch_id}",
+            mapping={
+                "hashes": json.dumps(hashes),
+                "mask": mask,
+                "wordlist": wordlist,
+                "created": int(time.time()),
+                "target": json.dumps(target),
+                "status": "queued",
+            },
+        )
+        r.expire(f"batch:{batch_id}", ttl)
+        r.lpush("batch:queue", batch_id)
+    except redis.exceptions.RedisError as e:
+        print(f"Redis unavailable: {e}")
+        return None
     return batch_id
 
 
 def get_next_batch():
-    batch_id = r.rpop("batch:queue")
-    if not batch_id:
+    try:
+        batch_id = r.rpop("batch:queue")
+        if not batch_id:
+            return None
+        data = r.hgetall(f"batch:{batch_id}")
+        data["batch_id"] = batch_id
+        return data
+    except redis.exceptions.RedisError as e:
+        print(f"Redis unavailable: {e}")
         return None
-    data = r.hgetall(f"batch:{batch_id}")
-    data["batch_id"] = batch_id
-    return data
 
 
 def requeue_batch(batch_id):
-    r.lpush("batch:queue", batch_id)
+    try:
+        r.lpush("batch:queue", batch_id)
+    except redis.exceptions.RedisError as e:
+        print(f"Redis unavailable: {e}")

--- a/Server/redis_utils.py
+++ b/Server/redis_utils.py
@@ -1,0 +1,21 @@
+import os
+import json
+from pathlib import Path
+import redis
+
+CONFIG_FILE = Path.home() / ".hashmancer" / "server_config.json"
+
+
+def get_redis() -> redis.Redis:
+    """Return a Redis connection using env vars or server_config.json."""
+    host = os.getenv("REDIS_HOST", "localhost")
+    port = int(os.getenv("REDIS_PORT", "6379"))
+    if CONFIG_FILE.exists():
+        try:
+            with open(CONFIG_FILE) as f:
+                cfg = json.load(f)
+            host = os.getenv("REDIS_HOST", cfg.get("redis_host", host))
+            port = int(os.getenv("REDIS_PORT", cfg.get("redis_port", port)))
+        except Exception:
+            pass
+    return redis.Redis(host=host, port=port, decode_responses=True)


### PR DESCRIPTION
## Summary
- centralize Redis connection setup in `redis_utils.get_redis`
- use new helper across server modules
- handle `RedisError` in server endpoints and tools

## Testing
- `python -m py_compile Server/*.py Worker/hashmancer_worker/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687973aedc988326a7fc7358661abece