### PR TITLE
Add pattern utils tests

### DIFF
--- a/Server/__init__.py
+++ b/Server/__init__.py
@@ -1,0 +1,1 @@
+"""Hashmancer server package."""

--- a/Server/pattern_utils.py
+++ b/Server/pattern_utils.py
@@ -25,7 +25,7 @@ def word_to_pattern(word: str) -> str:
     return "".join(pattern)
 
 
-MASK_RE = re.compile(r"\$(?:U|l|d|s)+")
+MASK_RE = re.compile(r"(?:\$[Ulds])+")
 
 
 def is_valid_pattern(mask: str) -> bool:

--- a/tests/test_pattern_utils.py
+++ b/tests/test_pattern_utils.py
@@ -1,0 +1,19 @@
+import os
+import sys
+import pytest
+
+# Allow importing the Server package from the repository root
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from Server.pattern_utils import word_to_pattern, is_valid_pattern
+
+
+def test_word_to_pattern():
+    assert word_to_pattern("Dark12!") == "$U$l$l$l$d$d$s"
+
+
+def test_is_valid_pattern():
+    pattern = word_to_pattern("Dark12!")
+    assert is_valid_pattern(pattern)
+    assert not is_valid_pattern("$Ulldds")
+    assert not is_valid_pattern("invalid")


### PR DESCRIPTION
## Summary
- add unit tests for pattern utilities
- fix regex in `is_valid_pattern`
- make `Server` a package for imports

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879be4bf07083269bc337c299e3e776