### PR TITLE
Enhance server dashboard

### DIFF
--- a/Server/README.md
+++ b/Server/README.md
@@ -93,12 +93,17 @@ any device on your network. Start the server with `uvicorn` as shown above and
 open your browser to `http://<server-ip>:8000/glyph`.
 
 The page refreshes every few seconds and displays worker counts, queue length,
-found results, and GPU temperatures. It also lists all connected workers with a
-drop-down to change their status (for example `idle`, `maintenance`, or
-`offline`). The layout is landscape friendly so you can mount an old Android
-phone or tablet on your rack and use it to interact with and monitor the
-server. A simple hashrate chart lets you switch between total rate or a
-specific worker so you can keep an eye on performance over time.
+found results, and GPU temperatures. Recent cracked hashes are shown in a small
+list so you can quickly verify progress. Worker statuses are now color-coded
+(`idle` in green, `maintenance` in orange, `offline` in red) for easier at-a-
+glance monitoring. The footer shows the last update time.
+
+All connected workers are listed with a drop-down to change their status
+(for example `idle`, `maintenance`, or `offline`). The layout is landscape
+friendly so you can mount an old Android phone or tablet on your rack and use
+it to interact with and monitor the server. A simple hashrate chart lets you
+switch between total rate or a specific worker so you can keep an eye on
+performance over time.
 
 ---
 

--- a/Server/glyph.html
+++ b/Server/glyph.html
@@ -28,6 +28,9 @@ th, td {
     padding: 4px;
     text-align: center;
 }
+td.status-idle { color: #0f0; }
+td.status-maintenance { color: #ff8800; }
+td.status-offline { color: #f00; }
 select {
     background: #222;
     color: #eee;
@@ -46,6 +49,10 @@ canvas {
 <div class="section">Queue Length: <span id="queue">0</span></div>
 <div class="section">Found Results: <span id="results">0</span></div>
 <div class="section">GPU Temps: <span id="gpu">N/A</span></div>
+<div class="section">Recent Cracks:
+  <ul id="found-list"></ul>
+</div>
+<div class="section" id="updated">Updated: never</div>
 <div class="section">
   Hashrate Target:
   <select id="hashrate-target" onchange="loadHashrate()">
@@ -69,6 +76,19 @@ async function updateMetrics() {
     document.getElementById('queue').textContent = data.queue_length;
     document.getElementById('results').textContent = data.found_results;
     document.getElementById('gpu').textContent = (data.gpu_temps || []).join(', ');
+    document.getElementById('updated').textContent = 'Updated: ' + new Date().toLocaleTimeString();
+}
+
+async function loadFoundResults() {
+    const res = await fetch('/found_results?limit=5');
+    const list = await res.json();
+    const ul = document.getElementById('found-list');
+    ul.innerHTML = '';
+    for (const line of list) {
+        const li = document.createElement('li');
+        li.textContent = line;
+        ul.appendChild(li);
+    }
 }
 
 async function loadWorkers() {
@@ -82,6 +102,7 @@ async function loadWorkers() {
         nameTd.textContent = w.name;
         const statusTd = document.createElement('td');
         statusTd.textContent = w.status;
+        statusTd.className = 'status-' + w.status;
         const actionTd = document.createElement('td');
         const select = document.createElement('select');
         for (const opt of ['idle', 'maintenance', 'offline']) {
@@ -98,6 +119,7 @@ async function loadWorkers() {
                 body: JSON.stringify({ name: w.name, status: select.value })
             });
             statusTd.textContent = select.value;
+            statusTd.className = 'status-' + select.value;
         };
         actionTd.appendChild(select);
         tr.appendChild(nameTd);
@@ -110,6 +132,7 @@ async function loadWorkers() {
 function tick() {
     updateMetrics();
     loadWorkers();
+    loadFoundResults();
     loadHashrate();
 }
 setInterval(tick, 5000);


### PR DESCRIPTION
## Summary
- add colored status indicators and recent results list to `glyph.html`
- show last update time and highlight worker state changes
- document Glyph dashboard improvements in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b0946a7988326a6febda70cb2dad2