### PR TITLE
Add hash upload validation

### DIFF
--- a/Server/README.md
+++ b/Server/README.md
@@ -18,6 +18,7 @@ Hashmancer is a high-performance, distributed hash cracking orchestration system
 - Agents handle PCIe-aware mask, dictionary, and hybrid attacks
 - GPU specs are stored in Redis for tuning
 - Each GPU spec includes a `pci_link_width` field used to route work
+- `hashescom_client.upload_founds` returns `True` when the API confirms receipt
 - Redis-based orchestrator balances batches between high- and low-bandwidth queues
 - Optional UDP broadcast so workers on the local network can auto-discover the server
 

--- a/Server/hashescom_client.py
+++ b/Server/hashescom_client.py
@@ -23,17 +23,23 @@ def fetch_jobs():
         return []
 
 
-def upload_founds(algo_id, found_file):
+def upload_founds(algo_id, found_file) -> bool:
+    """Upload found hashes and return True if the API confirms success."""
     try:
         url = "https://hashes.com/en/api/founds"
-        files = {"userfile": open(found_file, "rb")}
-        data = {"algo": str(algo_id), "key": HASHES_API or ""}
-        resp = requests.post(url, files=files, data=data, timeout=10)
+        with open(found_file, "rb") as fh:
+            files = {"userfile": fh}
+            data = {"algo": str(algo_id), "key": HASHES_API or ""}
+            resp = requests.post(url, files=files, data=data, timeout=10)
         resp.raise_for_status()
-        return resp.json()
+        result = resp.json()
+        if not result.get("success"):
+            print(f"[❌] Upload rejected: {result}")
+            return False
+        return True
     except requests.HTTPError as e:
         print(f"[❌] Upload error: {e}")
-        return {}
+        return False
     except Exception as e:
         print(f"[❌] Upload error: {e}")
-        return {}
+        return False

--- a/tests/test_hashescom_client.py
+++ b/tests/test_hashescom_client.py
@@ -1,0 +1,40 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from Server import hashescom_client
+
+class DummyResp:
+    def __init__(self, json_data, status=200):
+        self._json = json_data
+        self.status_code = status
+
+    def json(self):
+        return self._json
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise Exception("HTTP error")
+
+
+def test_upload_founds_success(monkeypatch, tmp_path):
+    def mock_post(url, files=None, data=None, timeout=None):
+        return DummyResp({"success": True})
+
+    monkeypatch.setattr(hashescom_client.requests, "post", mock_post)
+    sample = tmp_path / "f.txt"
+    sample.write_text("hash:pass")
+
+    assert hashescom_client.upload_founds(0, str(sample))
+
+
+def test_upload_founds_failure(monkeypatch, tmp_path):
+    def mock_post(url, files=None, data=None, timeout=None):
+        return DummyResp({"success": False})
+
+    monkeypatch.setattr(hashescom_client.requests, "post", mock_post)
+    sample = tmp_path / "f.txt"
+    sample.write_text("hash:pass")
+
+    assert not hashescom_client.upload_founds(0, str(sample))


### PR DESCRIPTION
## Summary
- verify Hashes.com found uploads in `hashescom_client.upload_founds`
- mention new behavior in server README
- add tests for the new helper

## Testing
- `pip install -r Server/requirements-dev.txt` *(fails: Could not connect to pypi.org)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_687b0a4ac0f08326aceefab982b20bc5