### PR TITLE
Add restore upload endpoint

### DIFF
--- a/Server/README.md
+++ b/Server/README.md
@@ -119,6 +119,7 @@ performance over time.
 | GET    | `/get_batch`        | Worker requests a batch             |
 | POST   | `/submit_founds`    | Submit cracked hashes               |
 | POST   | `/submit_no_founds` | Report a finished batch with none   |
+| POST   | `/upload_restore`   | Upload a `.restore` file from a worker |
 | GET    | `/wordlists`        | List available wordlists            |
 | GET    | `/masks`            | List available masks                |
 | GET    | `/rules`            | List available hashcat rules        |


### PR DESCRIPTION
## Summary
- add configurable RESTORE_DIR
- implement `/upload_restore` endpoint
- log uploaded restore files via `log_info`
- document new endpoint in the API table

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_687b9e5e421c8326a435cc0b2781afb8