### PR TITLE
Add coverage for orchestrator and GPU sidecar

### DIFF
--- a/tests/test_gpu_sidecar.py
+++ b/tests/test_gpu_sidecar.py
@@ -1,0 +1,72 @@
+import os
+import sys
+import json
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from Worker.hashmancer_worker import gpu_sidecar
+
+
+class FakeRedis:
+    def __init__(self):
+        self.store = {}
+
+    def get(self, key):
+        return self.store.get(key)
+
+    def hset(self, key, mapping=None, **kwargs):
+        pass
+
+
+class DummyStdout:
+    def __init__(self, lines):
+        self.lines = lines
+        self.idx = 0
+
+    def readline(self):
+        if self.idx < len(self.lines):
+            line = self.lines[self.idx]
+            self.idx += 1
+            return line
+        return ""
+
+
+class DummyProc:
+    def __init__(self, lines, outfile):
+        self.stdout = DummyStdout(lines)
+        self.returncode = 0
+        self.outfile = outfile
+        self.done = False
+
+    def poll(self):
+        if self.stdout.idx >= len(self.stdout.lines) and not self.done:
+            Path(self.outfile).write_text("hash:pass\n")
+            self.done = True
+            return self.returncode
+        return None
+
+
+def test_run_hashcat(monkeypatch):
+    sidecar = gpu_sidecar.GPUSidecar("worker", {"uuid": "gpu", "index": 0}, "http://sv")
+    monkeypatch.setattr(gpu_sidecar, "r", FakeRedis())
+
+    def fake_popen(cmd, stdout=None, stderr=None, text=None, env=None):
+        return DummyProc(['{"speed": [50], "progress": 10}'], "/tmp/job1.out")
+
+    monkeypatch.setattr(gpu_sidecar.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(gpu_sidecar.requests, "post", lambda *a, **k: None)
+
+    batch = {
+        "batch_id": "job1",
+        "hashes": json.dumps(["hash"]),
+        "mask": "?a",
+        "attack_mode": "mask",
+        "hash_mode": "0",
+    }
+
+    founds = sidecar.run_hashcat(batch)
+    assert founds == ["hash:pass"]
+    assert sidecar.hashrate == 50.0
+    assert sidecar.progress == 10
+

--- a/tests/test_orchestrator_agent.py
+++ b/tests/test_orchestrator_agent.py
@@ -1,0 +1,44 @@
+import os
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(__file__))
+sys.path.insert(0, ROOT)
+sys.path.insert(0, os.path.join(ROOT, "Server"))
+
+import orchestrator_agent
+
+orchestrator_agent.redis.exceptions.ResponseError = Exception
+
+
+class FakeRedis:
+    def __init__(self, info=None, raise_err=False):
+        self.info = info
+        self.raise_err = raise_err
+        self.group_created = False
+
+    def xpending(self, stream, group):
+        if self.raise_err:
+            raise orchestrator_agent.redis.exceptions.ResponseError("no group")
+        return self.info
+
+    def xgroup_create(self, stream, group, id="0", mkstream=True):
+        self.group_created = True
+
+
+def test_compute_backlog_target(monkeypatch):
+    monkeypatch.setattr(orchestrator_agent, "gpu_metrics", lambda: [(16, 10.0), (4, 0.0)])
+    assert orchestrator_agent.compute_backlog_target() == 7
+
+
+def test_pending_count_dict(monkeypatch):
+    fake = FakeRedis(info={"pending": 5})
+    monkeypatch.setattr(orchestrator_agent, "r", fake)
+    assert orchestrator_agent.pending_count() == 5
+
+
+def test_pending_count_create_group(monkeypatch):
+    fake = FakeRedis(info=None, raise_err=True)
+    monkeypatch.setattr(orchestrator_agent, "r", fake)
+    assert orchestrator_agent.pending_count() == 0
+    assert fake.group_created
+

--- a/tests/test_redis_manager.py
+++ b/tests/test_redis_manager.py
@@ -1,0 +1,46 @@
+import os
+import sys
+import json
+from uuid import UUID
+
+ROOT = os.path.dirname(os.path.dirname(__file__))
+sys.path.insert(0, ROOT)
+sys.path.insert(0, os.path.join(ROOT, "Server"))
+
+import redis_manager
+
+
+class FakeRedis:
+    def __init__(self):
+        self.store = {}
+        self.queue = []
+
+    def hset(self, key, mapping=None, **kwargs):
+        self.store[key] = dict(mapping or {})
+
+    def expire(self, key, ttl):
+        pass
+
+    def lpush(self, name, value):
+        self.queue.insert(0, value)
+
+    def rpop(self, name):
+        return self.queue.pop() if self.queue else None
+
+    def hgetall(self, key):
+        return dict(self.store.get(key, {}))
+
+
+def test_store_and_get_batch(monkeypatch):
+    fake = FakeRedis()
+    monkeypatch.setattr(redis_manager, "r", fake)
+    monkeypatch.setattr(redis_manager.uuid, "uuid4", lambda: UUID("11111111-1111-1111-1111-111111111111"))
+
+    batch_id = redis_manager.store_batch(["h"], mask="?a")
+    assert batch_id == "11111111-1111-1111-1111-111111111111"
+    assert fake.queue == [batch_id]
+
+    data = redis_manager.get_next_batch()
+    assert data["batch_id"] == batch_id
+    assert json.loads(data["hashes"]) == ["h"]
+    assert data["mask"] == "?a"


### PR DESCRIPTION
## Summary
- test backlog calculation and pending job count in orchestrator
- test storing and fetching batches from Redis
- mock subprocesses to exercise `GPUSidecar.run_hashcat`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ba120599c8326b5e3970211146e13