### PR TITLE
Cache signing keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,9 @@ GPU specs include a `pci_link_width` field for bandwidth-aware scheduling. The w
 Run `python3 setup.py` from the repository root to configure either a server or
 worker.  Use `--server` or `--worker` flags to skip the prompt.  A worker can
 also supply `--server-ip` to skip auto-discovery.
+
+## Thread Safety
+
+Both the server and worker load their private signing keys once at module import
+time.  The `cryptography` library returns immutable key objects, so concurrent
+threads can safely call the signing helpers without additional locking.

--- a/Server/signing_utils.py
+++ b/Server/signing_utils.py
@@ -1,3 +1,10 @@
+"""Helpers for signing server responses.
+
+The server loads the private key once at import time.  The key object returned
+by ``cryptography`` is immutable and safe to share between threads for signing
+operations.
+"""
+
 import base64
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding
@@ -11,7 +18,21 @@ def load_private_key():
     return serialization.load_pem_private_key(key_data, password=None)
 
 
+# Cache the server private key at import time.
+try:
+    _PRIVATE_KEY = load_private_key()
+except FileNotFoundError:
+    # Importing the module shouldn't fail in environments without the key.
+    # The key will be loaded on first call to ``sign_message``.
+    _PRIVATE_KEY = None
+
+
 def sign_message(message: str) -> str:
-    private_key = load_private_key()
-    signature = private_key.sign(message.encode(), padding.PKCS1v15(), hashes.SHA256())
+    """Return a base64 signature for ``message`` using the cached key."""
+    key = _PRIVATE_KEY
+    if key is None:
+        key = load_private_key()
+    signature = key.sign(
+        message.encode(), padding.PKCS1v15(), hashes.SHA256()
+    )
     return base64.b64encode(signature).decode()

--- a/Worker/hashmancer_worker/crypto_utils.py
+++ b/Worker/hashmancer_worker/crypto_utils.py
@@ -1,3 +1,11 @@
+"""Utility helpers for signing messages from the worker.
+
+The worker keeps the private key loaded at module import time so that each
+signing operation doesn't repeatedly read the key file.  The key object is
+immutable in the ``cryptography`` library, so sharing a single instance across
+threads is safe as long as the key is not modified.
+"""
+
 import os
 import base64
 from cryptography.hazmat.primitives import hashes, serialization
@@ -6,11 +14,24 @@ from cryptography.hazmat.primitives.asymmetric import padding
 PRIVATE_KEY_PATH = os.getenv("PRIVATE_KEY_PATH", "./worker_private_key.pem")
 PUBLIC_KEY_PATH = os.getenv("PUBLIC_KEY_PATH", "./worker_public_key.pem")
 
+# Load the private key once so repeated signing doesn't hit the filesystem.
+# The returned key object from the cryptography library is immutable and safe
+# to use across threads for sign operations.
+
 
 def load_private_key():
     with open(PRIVATE_KEY_PATH, "rb") as f:
         key_data = f.read()
     return serialization.load_pem_private_key(key_data, password=None)
+
+
+# Cache the private key at import time for reuse.
+try:
+    _PRIVATE_KEY = load_private_key()
+except FileNotFoundError:
+    # Allow import in environments without the private key. The key will be
+    # loaded on first use of ``sign_message``.
+    _PRIVATE_KEY = None
 
 
 def load_public_key_pem() -> str:
@@ -19,6 +40,11 @@ def load_public_key_pem() -> str:
 
 
 def sign_message(message: str) -> str:
-    key = load_private_key()
-    signature = key.sign(message.encode(), padding.PKCS1v15(), hashes.SHA256())
+    """Return a base64 signature for the provided message."""
+    key = _PRIVATE_KEY
+    if key is None:
+        key = load_private_key()
+    signature = key.sign(
+        message.encode(), padding.PKCS1v15(), hashes.SHA256()
+    )
     return base64.b64encode(signature).decode()


### PR DESCRIPTION
## Summary
- load signing keys during import
- reuse cached key for signing
- add thread safety note

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ba486d0bc83268fd4211f44f8f837