### PR TITLE
Add configurable restore and backup directories

### DIFF
--- a/Server/README.md
+++ b/Server/README.md
@@ -184,6 +184,21 @@ def discover_server(timeout: int = 5, port: int = 50000) -> str | None:
 server = discover_server() or prompt("SERVER_URL", SERVER_URL)
 ```
 
+### Restore directories
+
+The server periodically checks `RESTORE_DIR` for any `.restore` files and moves
+processed files to `BACKUP_DIR`. Both paths can be configured through
+environment variables or `~/.hashmancer/server_config.json`:
+
+```json
+{
+  "restore_dir": "/opt/hashmancer/restores",
+  "backup_dir": "/opt/hashmancer/restore_backups"
+}
+```
+
+If not provided, the defaults are `./` for `RESTORE_DIR` and
+`./restore_backups` for `BACKUP_DIR`.
 
 ## 📈 Learning Password Trends
 


### PR DESCRIPTION
## Summary
- make restore and backup directories configurable via environment variables or `server_config.json`
- use these paths in `scan_restore_files` and `move_to_backup`
- document new settings in the server README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ba56de2708326bf7d32f350d930b5