### PR TITLE
Enhance backlog logic and unicode support

### DIFF
--- a/Server/learn_trends.py
+++ b/Server/learn_trends.py
@@ -15,7 +15,7 @@ def process_wordlists(directory: Path) -> None:
     for path in directory.iterdir():
         if not path.is_file():
             continue
-        with path.open("r", errors="ignore") as f:
+        with path.open("r", encoding="utf-8", errors="ignore") as f:
             for line in f:
                 word = line.strip()
                 if not is_valid_word(word):

--- a/Server/orchestrator_agent.py
+++ b/Server/orchestrator_agent.py
@@ -63,13 +63,13 @@ def compute_backlog_target() -> int:
     backlog = 2  # base
     for width, rate in gpu_metrics():
         if width >= 8:
-            backlog += 3
-            if rate > 0:
-                backlog += 1
+            backlog += 4
+        elif width >= 4:
+            backlog += 2
         else:
             backlog += 1
-            if rate > 0:
-                backlog += 1
+        if rate > 0:
+            backlog += 1
     return backlog
 
 

--- a/Server/pattern_stats.py
+++ b/Server/pattern_stats.py
@@ -22,7 +22,7 @@ def update_stats(directory: Path) -> None:
     for path in directory.iterdir():
         if not path.is_file():
             continue
-        with path.open("r", errors="ignore") as f:
+        with path.open("r", encoding="utf-8", errors="ignore") as f:
             for line in f:
                 word = line.strip()
                 if not is_valid_word(word):

--- a/Server/pattern_utils.py
+++ b/Server/pattern_utils.py
@@ -35,12 +35,10 @@ def is_valid_pattern(mask: str) -> bool:
 
 
 def is_valid_word(word: str) -> bool:
-    """Return ``True`` if *word* is ASCII, <= 25 chars and contains no spaces."""
+    """Return ``True`` if *word* is <= 25 chars and contains no spaces."""
     if not word:
         return False
     if len(word) > 25:
-        return False
-    if not word.isascii():
         return False
     if any(ch.isspace() for ch in word):
         return False

--- a/tests/test_orchestrator_agent.py
+++ b/tests/test_orchestrator_agent.py
@@ -27,7 +27,7 @@ class FakeRedis:
 
 def test_compute_backlog_target(monkeypatch):
     monkeypatch.setattr(orchestrator_agent, "gpu_metrics", lambda: [(16, 10.0), (4, 0.0)])
-    assert orchestrator_agent.compute_backlog_target() == 7
+    assert orchestrator_agent.compute_backlog_target() == 9
 
 
 def test_pending_count_dict(monkeypatch):

--- a/tests/test_pattern_utils.py
+++ b/tests/test_pattern_utils.py
@@ -25,7 +25,7 @@ def test_is_valid_pattern():
         ("Password123", True),
         ("toolongwordthatexceedstwentyfivechars", False),
         ("spa ce", False),
-        ("nönascii", False),
+        ("nönascii", True),
         ("", False),
     ],
 )


### PR DESCRIPTION
## Summary
- tune `compute_backlog_target` to weight GPU PCIe bandwidths (>=8x, 4x, else)
- allow non‑ASCII words when building password patterns
- open wordlist files with UTF‑8 for wider character support
- update unit tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bbe25b330832686ea60a46a3f7682