### PR TITLE
Support alternative engine for low bandwidth GPUs

### DIFF
--- a/Server/main.py
+++ b/Server/main.py
@@ -38,6 +38,10 @@ MASKS_DIR = Path(CONFIG.get("masks_dir", "/opt/hashmancer/masks"))
 RULES_DIR = Path(CONFIG.get("rules_dir", "/opt/hashmancer/rules"))
 RESTORE_DIR = Path(CONFIG.get("restore_dir", "/opt/hashmancer/restores"))
 
+# select which cracking engine low bandwidth workers should use. The
+# specialized option is called "darkling".
+LOW_BW_ENGINE = CONFIG.get("low_bw_engine", "hashcat")
+
 # broadcast settings
 BROADCAST_ENABLED = bool(CONFIG.get("broadcast_enabled", True))
 BROADCAST_PORT = int(CONFIG.get("broadcast_port", 50000))
@@ -286,6 +290,7 @@ async def server_status():
             "queue_length": r.llen("batch:queue"),
             "found_results": r.llen("found:results"),
             "gpu_temps": get_gpu_temps(),
+            "low_bw_engine": LOW_BW_ENGINE,
         }
         return status
     except redis.exceptions.RedisError as e:


### PR DESCRIPTION
## Summary
- add `low_bw_engine` server config option and expose via `/server_status`
- teach GPU sidecar to fetch this setting and switch engines when PCIe width is low
- introduce `_run_engine`, `run_hashcat`, and `run_darkling_engine`
- test that darkling engine is selected under the right conditions
- rename previous "mask" engine terminology to "darkling"

## Testing
- `pip install -r Server/requirements-dev.txt` *(fails: Could not fetch packages)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bd10d7170832685944a0f93d3e48a