### PR TITLE
Add GPU power limit support

### DIFF
--- a/Worker/README.md
+++ b/Worker/README.md
@@ -38,6 +38,9 @@ Two optional environment variables allow you to tweak how `hashcat` runs:
 
 - `HASHCAT_WORKLOAD` – passed to `hashcat` as `-w`. Set `4` for maximum GPU load.
 - `HASHCAT_OPTIMIZED` – when `1`, adds `-O` to enable optimized kernels.
+- `GPU_POWER_LIMIT` – if set, attempts to cap GPU power in watts using
+  vendor tools (`nvidia-smi`, `rocm-smi`, or `intel_gpu_frequency`) before
+  launching the cracking engine.
 
 Example:
 


### PR DESCRIPTION
## Summary
- expose GPU_POWER_LIMIT variable in worker modules
- apply limit via nvidia-smi, rocm-smi or intel_gpu_frequency
- document GPU power limits in worker README
- extend tests to cover vendor-specific power limiting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bd5fbe738832691a5f386f7108604