### PR TITLE
Add GPU tuning and multithreaded logging

### DIFF
--- a/Worker/README.md
+++ b/Worker/README.md
@@ -41,6 +41,13 @@ Two optional environment variables allow you to tweak how `hashcat` runs:
 - `GPU_POWER_LIMIT` – if set, attempts to cap GPU power in watts using
   vendor tools (`nvidia-smi`, `rocm-smi`, or `intel_gpu_frequency`) before
   launching the cracking engine.
+- `DARKLING_GPU_POWER_LIMIT` – similar to `GPU_POWER_LIMIT` but only applied
+  when the darkling engine is used. This allows independent tuning of
+  experimental kernels.
+
+Each detected GPU is assigned its own sidecar thread so multiple devices run in
+parallel.  Logging and watchdog tasks now execute in dedicated threads inside
+the sidecars to avoid blocking GPU kernels.
 
 Example:
 

--- a/darkling/README.md
+++ b/darkling/README.md
@@ -26,3 +26,19 @@ g++ darkling_host.cpp -o darkling-host -lcuda -lcudart
 
 It preloads the kernel data into GPU memory and invokes `launch_darkling` across
 multiple counter ranges without re-allocating buffers.
+
+## Tuning
+
+When run as part of the worker each GPU receives its own darkling instance.
+Optional environment variables control power limits and autotuning:
+
+- `DARKLING_GPU_POWER_LIMIT` – apply a static power cap before launching the
+  kernel.
+- `DARKLING_TARGET_POWER_LIMIT` – attempt to reduce grid size if power draw
+  exceeds this threshold.
+- `DARKLING_AUTOTUNE` – when set, grid and block sizes are chosen based on
+  device properties using `cudaOccupancyMaxActiveBlocksPerMultiprocessor`. The
+  first batch measures hash/s and the configuration is adjusted automatically.
+
+These variables can be used in combination with the worker's per-GPU sidecars to
+balance performance across multiple devices.


### PR DESCRIPTION
## Summary
- support DARKLING_GPU_POWER_LIMIT and async status monitoring
- document tuning and sidecar behavior
- autotune grid/block sizes in darkling host

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c12f14c88832688cbb011a6aca5da