### PR TITLE
Add Darkling GPU shared types and modular build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,49 @@
+cmake_minimum_required(VERSION 3.13)
+project(darkling LANGUAGES C CXX)
+
+option(ENABLE_CUDA "Enable CUDA backend" ON)
+option(ENABLE_HIP "Enable HIP backend" ON)
+option(ENABLE_OPENCL "Enable OpenCL backend" ON)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+include_directories(${CMAKE_SOURCE_DIR}/core)
+
+file(GLOB CORE_SRC core/*.cpp core/utils/*.cpp)
+file(GLOB LAUNCHER_SRC launcher/*.cpp)
+
+set(DARKLING_SRCS ${CORE_SRC} ${LAUNCHER_SRC})
+
+# CUDA Backend
+if(ENABLE_CUDA)
+  enable_language(CUDA)
+  file(GLOB CUDA_SRC cuda_backend/*.cu)
+  add_library(cuda_backend STATIC ${CUDA_SRC})
+  target_compile_options(cuda_backend PRIVATE -O3 -Xcompiler -Wall)
+  target_include_directories(cuda_backend PRIVATE ${CMAKE_SOURCE_DIR}/core)
+  list(APPEND DARKLING_SRCS $<TARGET_OBJECTS:cuda_backend>)
+endif()
+
+# HIP Backend
+if(ENABLE_HIP)
+  find_package(HIP REQUIRED)
+  file(GLOB HIP_SRC hip_backend/*.hip)
+  hip_add_library(hip_backend STATIC ${HIP_SRC})
+  target_include_directories(hip_backend PRIVATE ${CMAKE_SOURCE_DIR}/core)
+  list(APPEND DARKLING_SRCS $<TARGET_OBJECTS:hip_backend>)
+endif()
+
+# OpenCL Backend
+if(ENABLE_OPENCL)
+  find_package(OpenCL REQUIRED)
+  file(GLOB OPENCL_SRC intel_backend/*.cpp)
+  add_library(opencl_backend STATIC ${OPENCL_SRC})
+  target_include_directories(opencl_backend PRIVATE ${CMAKE_SOURCE_DIR}/core)
+  target_link_libraries(opencl_backend PRIVATE OpenCL::OpenCL)
+  list(APPEND DARKLING_SRCS $<TARGET_OBJECTS:opencl_backend>)
+endif()
+
+# Final Executable
+add_executable(darkling_launcher ${DARKLING_SRCS})
+target_compile_options(darkling_launcher PRIVATE -O3 -Wall)

--- a/darkling/backend_dispatcher.cpp
+++ b/darkling/backend_dispatcher.cpp
@@ -20,12 +20,20 @@ static GpuBackend detect_backend() {
 int main(int argc, char** argv) {
     GpuBackend backend = detect_backend();
     auto cracker = create_backend(backend);
-    JobConfig cfg{20, 4};
-    cracker->initialize(cfg);
-    cracker->load_data({}, {}, {});
-    cracker->launch_crack_batch(0, 1000);
+    cracker->initialize();
+    MaskJob job{};
+    job.start_index = 0;
+    job.end_index = 1000;
+    job.mask_length = 0;
+    job.hash_length = 20;
+    job.num_hashes = 0;
+    cracker->load_job(job);
+    cracker->run_batch();
     auto res = cracker->read_results();
-    for (auto& s : res) std::cout << s << "\n";
-    std::cout << cracker->get_status() << std::endl;
+    for (auto& r : res) {
+        std::cout << r.candidate_index << "\n";
+    }
+    auto status = cracker->get_status();
+    std::cout << status.hashes_processed << std::endl;
     return 0;
 }

--- a/darkling/cuda_backend/cuda_cracker.cu
+++ b/darkling/cuda_backend/cuda_cracker.cu
@@ -9,36 +9,34 @@ namespace darkling {
 CudaCracker::CudaCracker() {}
 CudaCracker::~CudaCracker() {}
 
-bool CudaCracker::initialize(const JobConfig &cfg) {
-    config_ = cfg;
+bool CudaCracker::initialize() {
     cudaGetDevice(&device_id_);
     return true;
 }
 
-bool CudaCracker::load_data(const std::vector<std::string> &charsets,
-                            const std::vector<uint8_t> &position_map,
-                            const std::vector<uint8_t> &hashes) {
+bool CudaCracker::load_job(const MaskJob &job) {
+    job_ = job;
     // Reuse logic from DarklingContext in darkling_host.cpp
     return true; // placeholder
 }
 
-bool CudaCracker::launch_crack_batch(uint64_t start, uint64_t end) {
+bool CudaCracker::run_batch() {
     dim3 grid{128};
     dim3 block{256};
     // Actual kernel launch would mirror darkling_host.cpp
     launch_darkling(nullptr, nullptr, nullptr, nullptr,
-                    config_.pwd_len, nullptr, 0, config_.hash_len,
-                    start, end, nullptr, 0, nullptr, grid, block);
+                    job_.mask_length, nullptr, 0, job_.hash_length,
+                    job_.start_index, job_.end_index, nullptr, 0, nullptr, grid, block);
     cudaDeviceSynchronize();
     return true;
 }
 
-std::vector<std::string> CudaCracker::read_results() {
+std::vector<CrackResult> CudaCracker::read_results() {
     return {}; // placeholder
 }
 
-std::string CudaCracker::get_status() {
-    return "cuda";
+GpuStatus CudaCracker::get_status() {
+    return {};
 }
 
 } // namespace darkling

--- a/darkling/cuda_backend/cuda_cracker.h
+++ b/darkling/cuda_backend/cuda_cracker.h
@@ -11,17 +11,15 @@ public:
     CudaCracker();
     ~CudaCracker() override;
 
-    bool initialize(const JobConfig &config) override;
-    bool load_data(const std::vector<std::string> &charsets,
-                   const std::vector<uint8_t> &position_map,
-                   const std::vector<uint8_t> &hashes) override;
-    bool launch_crack_batch(uint64_t start, uint64_t end) override;
-    std::vector<std::string> read_results() override;
-    std::string get_status() override;
+    bool initialize() override;
+    bool load_job(const MaskJob &job) override;
+    bool run_batch() override;
+    std::vector<CrackResult> read_results() override;
+    GpuStatus get_status() override;
 
 private:
     int device_id_ = 0;
-    JobConfig config_{};
+    MaskJob job_{};
 };
 
 } // namespace darkling

--- a/darkling/gpu_backend.h
+++ b/darkling/gpu_backend.h
@@ -5,6 +5,7 @@
 #include <vector>
 #include <cstdint>
 #include <string>
+#include "gpu_shared_types.h"
 
 namespace darkling {
 
@@ -14,20 +15,13 @@ enum class GpuBackend {
     INTEL_OPENCL
 };
 
-struct JobConfig {
-    int hash_len = 0;
-    int pwd_len = 0;
-};
-
 struct GpuCracker {
     virtual ~GpuCracker() = default;
-    virtual bool initialize(const JobConfig &config) = 0;
-    virtual bool load_data(const std::vector<std::string> &charsets,
-                           const std::vector<uint8_t> &position_map,
-                           const std::vector<uint8_t> &hashes) = 0;
-    virtual bool launch_crack_batch(uint64_t start, uint64_t end) = 0;
-    virtual std::vector<std::string> read_results() = 0;
-    virtual std::string get_status() = 0;
+    virtual bool initialize() = 0;
+    virtual bool load_job(const MaskJob &job) = 0;
+    virtual bool run_batch() = 0;
+    virtual std::vector<CrackResult> read_results() = 0;
+    virtual GpuStatus get_status() = 0;
 };
 
 std::unique_ptr<GpuCracker> create_backend(GpuBackend type);

--- a/darkling/gpu_shared_types.h
+++ b/darkling/gpu_shared_types.h
@@ -1,0 +1,40 @@
+#pragma once
+#include <cstdint>
+#include <vector>
+#include <array>
+
+// Max limits
+#define MAX_CHARSETS 16
+#define MAX_MASK_LEN 32
+#define MAX_HASHES 4096
+#define MAX_RESULT_BUFFER 512
+
+// Job Configuration (passed to GPU)
+struct MaskJob {
+  uint64_t start_index;
+  uint64_t end_index;
+  uint8_t mask_length;
+  uint8_t mask_template[MAX_MASK_LEN];   // charset IDs per position (e.g., ?1?2?2?3 -> [1,2,2,3])
+  uint8_t charset_lengths[MAX_CHARSETS];
+  uint8_t charsets[MAX_CHARSETS][256];   // flattened LUTs (ASCII or binary)
+  uint8_t hash_type;                     // e.g., 1 = MD5, 2 = SHA1
+  uint8_t hash_length;
+  uint8_t hashes[MAX_HASHES][32];        // variable-length hash buffer (e.g., 16 for MD5)
+  uint32_t num_hashes;
+};
+
+// GPU result record
+struct CrackResult {
+  uint64_t candidate_index;
+  uint8_t hash[32];      // Matched hash
+  uint8_t password[32];  // Cracked plaintext
+  uint8_t length;
+};
+
+// GPU status block
+struct GpuStatus {
+  uint64_t hashes_processed;
+  float gpu_temp_c;
+  float batch_duration_ms;
+  bool overheat_flag;
+};

--- a/darkling/hip_backend/hip_cracker.cpp
+++ b/darkling/hip_backend/hip_cracker.cpp
@@ -6,29 +6,25 @@ namespace darkling {
 HipCracker::HipCracker() {}
 HipCracker::~HipCracker() {}
 
-bool HipCracker::initialize(const JobConfig &config) {
-    (void)config;
+bool HipCracker::initialize() {
     return true;
 }
 
-bool HipCracker::load_data(const std::vector<std::string> &charsets,
-                           const std::vector<uint8_t> &position_map,
-                           const std::vector<uint8_t> &hashes) {
-    (void)charsets; (void)position_map; (void)hashes;
+bool HipCracker::load_job(const MaskJob &job) {
+    (void)job;
     return true;
 }
 
-bool HipCracker::launch_crack_batch(uint64_t start, uint64_t end) {
-    (void)start; (void)end;
+bool HipCracker::run_batch() {
     return true;
 }
 
-std::vector<std::string> HipCracker::read_results() {
+std::vector<CrackResult> HipCracker::read_results() {
     return {};
 }
 
-std::string HipCracker::get_status() {
-    return "hip";
+GpuStatus HipCracker::get_status() {
+    return {};
 }
 
 } // namespace darkling

--- a/darkling/hip_backend/hip_cracker.h
+++ b/darkling/hip_backend/hip_cracker.h
@@ -10,13 +10,11 @@ public:
     HipCracker();
     ~HipCracker() override;
 
-    bool initialize(const JobConfig &config) override;
-    bool load_data(const std::vector<std::string> &charsets,
-                   const std::vector<uint8_t> &position_map,
-                   const std::vector<uint8_t> &hashes) override;
-    bool launch_crack_batch(uint64_t start, uint64_t end) override;
-    std::vector<std::string> read_results() override;
-    std::string get_status() override;
+    bool initialize() override;
+    bool load_job(const MaskJob &job) override;
+    bool run_batch() override;
+    std::vector<CrackResult> read_results() override;
+    GpuStatus get_status() override;
 };
 
 } // namespace darkling

--- a/darkling/intel_backend/intel_cracker.cpp
+++ b/darkling/intel_backend/intel_cracker.cpp
@@ -6,29 +6,25 @@ namespace darkling {
 IntelCracker::IntelCracker() {}
 IntelCracker::~IntelCracker() {}
 
-bool IntelCracker::initialize(const JobConfig &config) {
-    (void)config;
+bool IntelCracker::initialize() {
     return true;
 }
 
-bool IntelCracker::load_data(const std::vector<std::string> &charsets,
-                             const std::vector<uint8_t> &position_map,
-                             const std::vector<uint8_t> &hashes) {
-    (void)charsets; (void)position_map; (void)hashes;
+bool IntelCracker::load_job(const MaskJob &job) {
+    (void)job;
     return true;
 }
 
-bool IntelCracker::launch_crack_batch(uint64_t start, uint64_t end) {
-    (void)start; (void)end;
+bool IntelCracker::run_batch() {
     return true;
 }
 
-std::vector<std::string> IntelCracker::read_results() {
+std::vector<CrackResult> IntelCracker::read_results() {
     return {};
 }
 
-std::string IntelCracker::get_status() {
-    return "intel";
+GpuStatus IntelCracker::get_status() {
+    return {};
 }
 
 } // namespace darkling

--- a/darkling/intel_backend/intel_cracker.h
+++ b/darkling/intel_backend/intel_cracker.h
@@ -10,13 +10,11 @@ public:
     IntelCracker();
     ~IntelCracker() override;
 
-    bool initialize(const JobConfig &config) override;
-    bool load_data(const std::vector<std::string> &charsets,
-                   const std::vector<uint8_t> &position_map,
-                   const std::vector<uint8_t> &hashes) override;
-    bool launch_crack_batch(uint64_t start, uint64_t end) override;
-    std::vector<std::string> read_results() override;
-    std::string get_status() override;
+    bool initialize() override;
+    bool load_job(const MaskJob &job) override;
+    bool run_batch() override;
+    std::vector<CrackResult> read_results() override;
+    GpuStatus get_status() override;
 };
 
 } // namespace darkling


### PR DESCRIPTION
## Summary
- define shared GPU data structures in `gpu_shared_types.h`
- use these types across all Darkling backends
- add modular `CMakeLists.txt` for optional CUDA/HIP/OpenCL builds

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c2a3639048326b5872c42f26b65ea