### PR TITLE
Apply neon green style to dashboard pages

### DIFF
--- a/Server/admin.html
+++ b/Server/admin.html
@@ -4,15 +4,16 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>Hashmancer Admin</title>
+<link href="https://fonts.googleapis.com/css2?family=UnifrakturCook&display=swap" rel="stylesheet">
 <style>
-body { font-family: Arial, sans-serif; margin: 10px; background:#111; color:#eee; }
-h1 { color:#ffcc00; text-align:center; }
+body { font-family: Arial, sans-serif; margin: 10px; background:#000; color:#0f0; }
+h1 { color:#0f0; text-align:center; font-family:'UnifrakturCook', cursive; }
 section { margin-bottom:1.2em; }
 table { width:100%; border-collapse:collapse; margin-top:0.5em; }
-th,td { border:1px solid #555; padding:4px; text-align:center; }
-input, textarea, select { background:#222; color:#eee; border:1px solid #555; }
+th,td { border:1px solid #0f0; padding:4px; text-align:center; }
+input, textarea, select { background:#111; color:#0f0; border:1px solid #0f0; }
 button { margin-top:4px; }
-pre { background:#222; padding:5px; overflow:auto; max-height:200px; }
+pre { background:#111; color:#0f0; padding:5px; overflow:auto; max-height:200px; }
 </style>
 </head>
 <body>

--- a/Server/glyph.html
+++ b/Server/glyph.html
@@ -4,16 +4,18 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>Glyph Dashboard</title>
+<link href="https://fonts.googleapis.com/css2?family=UnifrakturCook&display=swap" rel="stylesheet">
 <style>
 body {
     font-family: Arial, sans-serif;
     margin: 10px;
-    background: #111;
-    color: #eee;
+    background: #000;
+    color: #0f0;
 }
 h1 {
-    color: #ffcc00;
+    color: #0f0;
     text-align: center;
+    font-family: 'UnifrakturCook', cursive;
 }
 .section {
     margin-bottom: 0.5em;
@@ -24,7 +26,7 @@ table {
     margin-top: 1em;
 }
 th, td {
-    border: 1px solid #555;
+    border: 1px solid #0f0;
     padding: 4px;
     text-align: center;
 }
@@ -32,9 +34,9 @@ td.status-idle { color: #0f0; }
 td.status-maintenance { color: #ff8800; }
 td.status-offline { color: #f00; }
 select {
-    background: #222;
-    color: #eee;
-    border: 1px solid #555;
+    background: #111;
+    color: #0f0;
+    border: 1px solid #0f0;
 }
 canvas {
     width: 100% !important;
@@ -152,7 +154,7 @@ async function loadHashrate() {
         const ctx = document.getElementById('hashrateChart').getContext('2d');
         chart = new Chart(ctx, {
             type: 'line',
-            data: { labels, datasets: [{ label: 'Hashrate', data: rates, borderColor: '#ffcc00', backgroundColor: 'rgba(255,204,0,0.2)' }] },
+            data: { labels, datasets: [{ label: 'Hashrate', data: rates, borderColor: '#0f0', backgroundColor: 'rgba(0,255,0,0.2)' }] },
             options: { scales: { y: { beginAtZero: true } } }
         });
     } else {


### PR DESCRIPTION
## Summary
- modernize dashboard and admin pages with neon green theme
- use UnifrakturCook font for occult vibe
- update chart colors and table borders to match theme

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c5788da0483269dbb32c13ed5e21e