### PR TITLE
Add protected portal routes

### DIFF
--- a/Server/README.md
+++ b/Server/README.md
@@ -196,9 +196,14 @@ environment variables or `~/.hashmancer/server_config.json`:
   "backup_dir": "/opt/hashmancer/restore_backups"
 }
 ```
-
 If not provided, the defaults are `./` for `RESTORE_DIR` and
 `./restore_backups` for `BACKUP_DIR`.
+
+### Portal API key
+
+To restrict access to the web dashboard set `"portal_key"` in
+`~/.hashmancer/server_config.json`. Requests to `/portal`, `/glyph` and
+`/admin` must then include an `X-API-Key` header with the same value.
 
 ## 📈 Learning Password Trends
 


### PR DESCRIPTION
## Summary
- enforce an optional API key for `/portal`, `/glyph`, and `/admin`
- document the new `portal_key` option

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cf27ed83883269df7e0cb5b64fd0a