### PR TITLE
Add websocket portal feed

### DIFF
--- a/Server/portal.html
+++ b/Server/portal.html
@@ -27,6 +27,11 @@ pre { background:#111; color:#0f0; padding:5px; overflow:auto; max-height:200px;
 <div id="updated">Updated: never</div>
 </section>
 
+<section id="founds">
+<h2>Found Hashes</h2>
+<pre id="found-output"></pre>
+</section>
+
 <section id="dicts">
 <h2>Dictionaries</h2>
 <ul id="dict-list"></ul>
@@ -61,14 +66,17 @@ pre { background:#111; color:#0f0; padding:5px; overflow:auto; max-height:200px;
 </section>
 
 <script>
-async function updateMetrics(){
-  const res = await fetch('/server_status');
-  const data = await res.json();
+function applyMetrics(data){
   document.getElementById('workers').textContent = data.worker_count;
   document.getElementById('queue').textContent = data.queue_length;
   document.getElementById('results').textContent = data.found_results;
   document.getElementById('gpu').textContent = (data.gpu_temps || []).join(',');
   document.getElementById('updated').textContent = 'Updated: ' + new Date().toLocaleTimeString();
+}
+async function updateMetrics(){
+  const res = await fetch('/server_status');
+  const data = await res.json();
+  applyMetrics(data);
 }
 
 async function loadDicts(){
@@ -185,7 +193,6 @@ async function loadJobs(){
 }
 
 function tick(){
-  updateMetrics();
   loadDicts();
   loadMasks();
   loadWorkers();
@@ -193,8 +200,24 @@ function tick(){
   loadLogs();
 }
 
-setInterval(tick,5000);
+function startWS(){
+  const proto = location.protocol === 'https:' ? 'wss' : 'ws';
+  const ws = new WebSocket(`${proto}://${location.host}/ws/portal`);
+  ws.onmessage = ev => {
+    const msg = JSON.parse(ev.data);
+    if(msg.metrics) applyMetrics(msg.metrics);
+    if(msg.founds && msg.founds.length){
+      const pre=document.getElementById('found-output');
+      pre.textContent += msg.founds.join('\n')+'\n';
+    }
+    if(msg.workers) loadWorkers();
+  };
+  ws.onclose = () => setTimeout(startWS, 1000);
+}
+
+setInterval(tick,30000);
 tick();
+startWS();
 </script>
 </body>
 </html>

--- a/tests/test_server_filepaths.py
+++ b/tests/test_server_filepaths.py
@@ -17,9 +17,13 @@ class FakeApp:
         return lambda f: f
     def delete(self, *a, **kw):
         return lambda f: f
+    def websocket(self, *a, **kw):
+        return lambda f: f
 fastapi_stub.FastAPI = lambda: FakeApp()
 fastapi_stub.UploadFile = object
 fastapi_stub.File = lambda *a, **kw: None
+fastapi_stub.WebSocket = object
+fastapi_stub.WebSocketDisconnect = type("WebSocketDisconnect", (), {})
 class HTTPException(Exception):
     pass
 fastapi_stub.HTTPException = HTTPException

--- a/tests/test_server_get_batch.py
+++ b/tests/test_server_get_batch.py
@@ -23,10 +23,15 @@ class FakeApp:
     def delete(self, *a, **kw):
         return lambda f: f
 
+    def websocket(self, *a, **kw):
+        return lambda f: f
+
 
 fastapi_stub.FastAPI = lambda: FakeApp()
 fastapi_stub.UploadFile = object
 fastapi_stub.File = lambda *a, **kw: None
+fastapi_stub.WebSocket = object
+fastapi_stub.WebSocketDisconnect = type("WebSocketDisconnect", (), {})
 
 
 class HTTPException(Exception):

--- a/tests/test_server_register.py
+++ b/tests/test_server_register.py
@@ -16,9 +16,13 @@ class FakeApp:
         return lambda f: f
     def delete(self, *a, **kw):
         return lambda f: f
+    def websocket(self, *a, **kw):
+        return lambda f: f
 fastapi_stub.FastAPI = lambda: FakeApp()
 fastapi_stub.UploadFile = object
 fastapi_stub.File = lambda *a, **kw: None
+fastapi_stub.WebSocket = object
+fastapi_stub.WebSocketDisconnect = type("WebSocketDisconnect", (), {})
 class HTTPException(Exception):
     pass
 fastapi_stub.HTTPException = HTTPException


### PR DESCRIPTION
## Summary
- push portal metrics via `/ws/portal` WebSocket
- show found hashes and update metrics live in `portal.html`
- adjust portal polling interval and add reconnecting WebSocket
- update tests to stub new FastAPI APIs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cf3d4a9148326b38a2c2bf4dda01e