### PR TITLE
Add GPU flashing feature

### DIFF
--- a/Worker/hashmancer_worker/bios_flasher.py
+++ b/Worker/hashmancer_worker/bios_flasher.py
@@ -1,0 +1,150 @@
+import os
+import time
+import threading
+import hashlib
+import subprocess
+import requests
+
+from .crypto_utils import sign_message
+
+
+def md5_speed() -> float:
+    """Return MB/s for computing md5 on random data."""
+    data = os.urandom(1024 * 1024)  # 1 MB block
+    start = time.time()
+    for _ in range(50):
+        hashlib.md5(data).digest()
+    duration = time.time() - start
+    if duration == 0:
+        return 0.0
+    return 50 / duration
+
+
+def apply_flash_settings(gpu: dict, settings: dict) -> bool:
+    """Attempt to apply clock/power settings to a GPU."""
+    index = str(gpu.get("index", 0))
+    vendor = settings.get("vendor", "nvidia").lower()
+    try:
+        if vendor == "nvidia":
+            pl = settings.get("power_limit")
+            if pl:
+                subprocess.check_call(
+                    [
+                        "nvidia-smi",
+                        "-i",
+                        index,
+                        "-pl",
+                        str(pl),
+                    ]
+                )
+            core = settings.get("core_clock")
+            if core:
+                subprocess.check_call(
+                    [
+                        "nvidia-smi",
+                        "-i",
+                        index,
+                        "--lock-gpu-clocks",
+                        str(core),
+                    ]
+                )
+            mem = settings.get("mem_clock")
+            if mem:
+                subprocess.check_call(
+                    [
+                        "nvidia-smi",
+                        "-i",
+                        index,
+                        "--lock-memory-clocks",
+                        str(mem),
+                    ]
+                )
+        elif vendor == "amd":
+            pl = settings.get("power_limit")
+            if pl:
+                subprocess.check_call(
+                    [
+                        "rocm-smi",
+                        "-d",
+                        index,
+                        "--setpowerlimit",
+                        str(pl),
+                    ]
+                )
+            core = settings.get("core_clock")
+            if core:
+                subprocess.check_call(
+                    [
+                        "rocm-smi",
+                        "-d",
+                        index,
+                        "--setsclk",
+                        str(core),
+                    ]
+                )
+            mem = settings.get("mem_clock")
+            if mem:
+                subprocess.check_call(
+                    [
+                        "rocm-smi",
+                        "-d",
+                        index,
+                        "--setmclk",
+                        str(mem),
+                    ]
+                )
+    except FileNotFoundError:
+        return False
+    except Exception:
+        return False
+    return True
+
+
+class GPUFlashManager(threading.Thread):
+    """Background thread that handles BIOS flashing/undervolting."""
+
+    def __init__(self, worker_id: str, server_url: str, gpus: list[dict]):
+        super().__init__(daemon=True)
+        self.worker_id = worker_id
+        self.server_url = server_url
+        self.gpus = gpus
+        self.running = True
+
+    def process_task(self, gpu_uuid: str, settings: dict):
+        gpu = next((g for g in self.gpus if g["uuid"] == gpu_uuid), None)
+        if not gpu:
+            return
+        baseline = md5_speed()
+        success = apply_flash_settings(gpu, settings)
+        post = md5_speed() if success else 0
+        success = success and post >= baseline * 0.8
+        payload = {
+            "worker_id": self.worker_id,
+            "gpu_uuid": gpu_uuid,
+            "success": success,
+            "signature": sign_message(self.worker_id),
+        }
+        try:
+            requests.post(f"{self.server_url}/flash_result", json=payload, timeout=5)
+        except Exception:
+            pass
+
+    def run(self):
+        while self.running:
+            try:
+                params = {
+                    "worker_id": self.worker_id,
+                    "signature": sign_message(self.worker_id),
+                }
+                resp = requests.get(
+                    f"{self.server_url}/get_flash_task", params=params, timeout=5
+                )
+                task = resp.json()
+                if task.get("status") != "ok":
+                    time.sleep(10)
+                    continue
+                gpu_uuid = task.get("gpu_uuid")
+                settings = task.get("settings", {})
+                self.process_task(gpu_uuid, settings)
+            except Exception:
+                time.sleep(5)

--- a/tests/test_flash_queue.py
+++ b/tests/test_flash_queue.py
@@ -1,0 +1,140 @@
+import asyncio
+import sys
+import os
+import types
+
+# Stub modules similar to other server tests
+fastapi_stub = types.ModuleType("fastapi")
+
+
+class FakeApp:
+    def add_middleware(self, *a, **kw):
+        pass
+
+    def on_event(self, *a, **kw):
+        return lambda f: f
+
+    def post(self, *a, **kw):
+        return lambda f: f
+
+    def get(self, *a, **kw):
+        return lambda f: f
+
+    def delete(self, *a, **kw):
+        return lambda f: f
+
+    def websocket(self, *a, **kw):
+        return lambda f: f
+
+
+fastapi_stub.FastAPI = lambda: FakeApp()
+fastapi_stub.UploadFile = object
+fastapi_stub.File = lambda *a, **kw: None
+fastapi_stub.WebSocket = object
+fastapi_stub.WebSocketDisconnect = type("WebSocketDisconnect", (), {})
+
+
+class HTTPException(Exception):
+    pass
+
+
+fastapi_stub.HTTPException = HTTPException
+sys.modules.setdefault("fastapi", fastapi_stub)
+
+cors_stub = types.ModuleType("fastapi.middleware.cors")
+cors_stub.CORSMiddleware = object
+sys.modules.setdefault("fastapi.middleware.cors", cors_stub)
+
+resp_stub = types.ModuleType("fastapi.responses")
+resp_stub.HTMLResponse = object
+sys.modules.setdefault("fastapi.responses", resp_stub)
+
+pydantic_stub = types.ModuleType("pydantic")
+
+
+class BaseModel:
+    pass
+
+
+pydantic_stub.BaseModel = BaseModel
+sys.modules.setdefault("pydantic", pydantic_stub)
+
+crypto_stub = types.ModuleType("cryptography")
+exceptions_stub = types.ModuleType("cryptography.exceptions")
+
+
+class InvalidSignature(Exception):
+    pass
+
+
+exceptions_stub.InvalidSignature = InvalidSignature
+primitives_stub = types.ModuleType("cryptography.hazmat.primitives")
+asym_stub = types.ModuleType("cryptography.hazmat.primitives.asymmetric")
+asym_stub.padding = object()
+primitives_stub.asymmetric = asym_stub
+primitives_stub.hashes = types.SimpleNamespace(SHA256=lambda: None)
+primitives_stub.serialization = types.SimpleNamespace(
+    load_pem_public_key=lambda x: None
+)
+crypto_stub.hazmat = types.SimpleNamespace(primitives=primitives_stub)
+crypto_stub.exceptions = exceptions_stub
+sys.modules.setdefault("cryptography", crypto_stub)
+sys.modules.setdefault("cryptography.exceptions", exceptions_stub)
+sys.modules.setdefault("cryptography.hazmat.primitives", primitives_stub)
+sys.modules.setdefault("cryptography.hazmat.primitives.asymmetric", asym_stub)
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), "Server"))
+
+import main
+
+
+class FakeRedis:
+    def __init__(self):
+        self.store = {}
+        self.lists = {}
+
+    def sadd(self, key, value):
+        self.store.setdefault(key, set()).add(value)
+
+    def smembers(self, key):
+        return self.store.get(key, set())
+
+    def hset(self, key, mapping=None, **kwargs):
+        self.store.setdefault(key, {}).update(mapping or {})
+
+    def rpush(self, key, value):
+        self.lists.setdefault(key, []).append(value)
+
+    def lpop(self, key):
+        vals = self.lists.get(key, [])
+        return vals.pop(0) if vals else None
+
+    def hincrby(self, key, field, amount):
+        val = int(self.store.get(key, {}).get(field, 0)) + amount
+        self.store.setdefault(key, {})[field] = val
+        return val
+
+    def hgetall(self, key):
+        return dict(self.store.get(key, {}))
+
+
+def test_flash_queue_on_register(monkeypatch):
+    fake = FakeRedis()
+    monkeypatch.setattr(main, "r", fake)
+    monkeypatch.setattr(main, "verify_signature_with_key", lambda a, b, c: True)
+    monkeypatch.setattr(main, "assign_waifu", lambda s: "Agent")
+    monkeypatch.setattr(main, "LOW_BW_ENGINE", "hashcat")
+
+    class Req:
+        worker_id = "id"
+        signature = "s"
+        pubkey = "p"
+        mode = "eco"
+        provider = "on-prem"
+        hardware = {"gpus": [{"uuid": "u1", "model": "RTX 3080", "index": 0}]}
+
+    resp = asyncio.run(main.register_worker(Req()))
+
+    assert resp["status"] == "ok"
+    assert fake.lists["flash:Agent"]

--- a/tests/test_gpu_flasher.py
+++ b/tests/test_gpu_flasher.py
@@ -1,0 +1,32 @@
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from Worker.hashmancer_worker import bios_flasher
+
+
+class DummyResp:
+    def __init__(self, data):
+        self._data = data
+
+    def json(self):
+        return self._data
+
+
+def test_process_task(monkeypatch):
+    sent = {}
+
+    def fake_post(url, json=None, timeout=None):
+        sent.update(json)
+
+    monkeypatch.setattr(bios_flasher.requests, "post", fake_post)
+    monkeypatch.setattr(bios_flasher, "md5_speed", lambda: 1.0)
+    monkeypatch.setattr(bios_flasher, "apply_flash_settings", lambda g, s: True)
+    monkeypatch.setattr(bios_flasher, "sign_message", lambda x: "sig")
+
+    mgr = bios_flasher.GPUFlashManager("w", "http://sv", [{"uuid": "u1", "index": 0}])
+    mgr.process_task("u1", {"vendor": "nvidia"})
+
+    assert sent["gpu_uuid"] == "u1"
+    assert sent["success"]


### PR DESCRIPTION
## Summary
- add baseline flash presets and queue GPUs on registration
- support retrieving/recording flash tasks through new API endpoints
- implement `GPUFlashManager` for workers
- cover flashing logic with tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d114a6f9c83269f9679f3095ca8c0