### PR TITLE
Add predefined charsets

### DIFF
--- a/darkling/README.md
+++ b/darkling/README.md
@@ -53,3 +53,30 @@ Each backend follows the same workflow of `initialize`, `load_data`,
 `launch_crack_batch` and result polling. Only the CUDA version contains a
 working kernel at the moment; the other backends provide build stubs for future
 expansion.
+
+## Predefined Charsets
+
+Several common alphabets and symbol sets are bundled in `charsets.py`.
+Import the desired constants when preparing mask attacks:
+
+```python
+from darkling.charsets import (
+    GERMAN_UPPER,
+    GERMAN_LOWER,
+    EMOJI,
+    CHINESE,
+    JAPANESE,
+)
+
+mask_charsets = {
+    '?1': GERMAN_UPPER,
+    '?2': GERMAN_LOWER,
+    '?3': EMOJI,
+    '?4': CHINESE,
+    '?5': JAPANESE,
+}
+```
+
+`charsets.py` exposes uppercase and lowercase alphabets for the top 20
+languages along with `COMMON_SYMBOLS`, `EMOJI`, and scripts such as
+`CHINESE` and `JAPANESE` for convenience.

--- a/darkling/charsets.py
+++ b/darkling/charsets.py
@@ -1,0 +1,83 @@
+"""Predefined character sets for the darkling engine."""
+
+# Emoji-only character set
+EMOJI = (
+    "😀😁😂🤣😃😄😅😆😉😊😋😎😍😘🥰😗😙😚🙂🤗"
+    "🤔🤨😐😑😶🙄😏😣😥😮🤐😯😪😫🥱😴😌😛😜😝"
+)
+
+# Fifteen most common special characters
+COMMON_SYMBOLS = "!@#$%^&*()-=+[]"
+
+# Uppercase and lowercase alphabets for major languages
+
+ENGLISH_UPPER = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+ENGLISH_LOWER = "abcdefghijklmnopqrstuvwxyz"
+
+SPANISH_UPPER = "AÁBCDEÉFGHIÍJKLMNÑOÓPQRSTUÚÜVWXYZ"
+SPANISH_LOWER = "aábcdeéfghiíjklmnñoópqrstuúüvwxyz"
+
+FRENCH_UPPER = "AÀÂÆBCÇDEÉÈÊËFGHIÎÏJKLMNOÔŒPQRSTUÙÛÜVWXYŸZ"
+FRENCH_LOWER = "aàâæbcçdeéèêëfghiîïjklmnoôœpqrstuùûüvwxyÿz"
+
+GERMAN_UPPER = "ABCDEFGHIJKLMNOPQRSTUVWXYZÄÖÜẞ"
+GERMAN_LOWER = "abcdefghijklmnopqrstuvwxyzäöüß"
+
+ITALIAN_UPPER = "AÀBCDEÉÈFGHIÌÍJKLMNOÒÓPQRSTUÙUVWXYZ"
+ITALIAN_LOWER = "aàbcdeéèfghiìíjklmnoòópqrstuùuvwxyz"
+
+PORTUGUESE_UPPER = "AÁÂÃÀBCÇDEÉÊFGHIÍJKLMNOÓÔÕPQRSTUÚÜVWXYZ"
+PORTUGUESE_LOWER = "aáâãàbcçdeéêfghiíjklmnoóôõpqrstuúüvwxyz"
+
+DUTCH_UPPER = "AÁBCDEÉFGHIÏJKLMNOÓPQRSTUÜVWXYZ"
+DUTCH_LOWER = "aábcdeéfghiïjklmnoópqrstuüvwxyz"
+
+SWEDISH_UPPER = "ABCDEFGHIJKLMNOPQRSTUVWXYZÅÄÖ"
+SWEDISH_LOWER = "abcdefghijklmnopqrstuvwxyzåäö"
+
+NORWEGIAN_UPPER = "ABCDEFGHIJKLMNOPQRSTUVWXYZÆØÅ"
+NORWEGIAN_LOWER = "abcdefghijklmnopqrstuvwxyzæøå"
+
+DANISH_UPPER = "ABCDEFGHIJKLMNOPQRSTUVWXYZÆØÅ"
+DANISH_LOWER = "abcdefghijklmnopqrstuvwxyzæøå"
+
+FINNISH_UPPER = "ABCDEFGHIJKLMNOPQRSTUVWXYZÅÄÖ"
+FINNISH_LOWER = "abcdefghijklmnopqrstuvwxyzåäö"
+
+POLISH_UPPER = "AĄBCĆDEĘFGHIJKLŁMNŃOÓPQRSŚTUVWXYZŹŻ"
+POLISH_LOWER = "aąbcćdeęfghijklłmnńoópqrsśtuvwxyzźż"
+
+CZECH_UPPER = "AÁBCČDĎEÉĚFGHIÍJKLMNŇOÓPQRŘSŠTŤUÚŮVWXYZÝŽ"
+CZECH_LOWER = "aábcčdďeéěfghiíjklmnňoópqrřsštťuúůvwxyzýž"
+
+HUNGARIAN_UPPER = "AÁBCDEÉFGHIÍJKLMNOÓÖŐPQRSTUÚÜŰVWXYZ"
+HUNGARIAN_LOWER = "aábcdeéfghiíjklmnoóöőpqrstuúüűvwxyz"
+
+ROMANIAN_UPPER = "ABCDEFGHIJKLMNOPQRSTUVWXYZĂÂÎȘȚ"
+ROMANIAN_LOWER = "abcdefghijklmnopqrstuvwxyzăâîșț"
+
+TURKISH_UPPER = "ABCÇDEFGĞHIİJKLMNOÖPRSŞTUÜVYZ"
+TURKISH_LOWER = "abcçdefgğhıijklmnoöprsştuüvyz"
+
+GREEK_UPPER = "ΑΒΓΔΕΖΗΘΙΚΛΜΝΞΟΠΡΣΤΥΦΧΨΩ"
+GREEK_LOWER = "αβγδεζηθικλμνξοπρστυφχψω"
+
+RUSSIAN_UPPER = "АБВГДЕЁЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯ"
+RUSSIAN_LOWER = "абвгдеёжзийклмнопрстуфхцчшщъыьэюя"
+
+# Languages without case
+ARABIC = "ابتثجحخدذرزسشصضطظعغفقكلمنهوي"
+HINDI = "अआइईउऊऋएऐओऔकखगघङचछजझञटठडढणतथदधनपफबभमयरलवशषसह"
+CHINESE = (
+    "的一是不了在人这有他我中大来上国到说们为子和你地出道也时年得就那要下以生"
+    "会自着去之过家学对可看她里后小么心多天"
+)
+JAPANESE_HIRAGANA = (
+    "あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほ"
+    "まみむめもやゆよらりるれろわをん"
+)
+JAPANESE_KATAKANA = (
+    "アイウエオカキクケコサシスセソタチツテトナニヌネノハヒフヘホ"
+    "マミムメモヤユヨラリルレロワヲン"
+)
+JAPANESE = JAPANESE_HIRAGANA + JAPANESE_KATAKANA

--- a/tests/test_charsets.py
+++ b/tests/test_charsets.py
@@ -1,0 +1,39 @@
+import os
+import sys
+import unicodedata
+
+ROOT = os.path.dirname(os.path.dirname(__file__))
+sys.path.insert(0, ROOT)
+
+from darkling import charsets
+
+
+def test_common_symbols_length():
+    assert len(charsets.COMMON_SYMBOLS) == 15
+
+
+def test_emoji_only_symbols():
+    assert all(unicodedata.category(c).startswith("S") for c in charsets.EMOJI)
+    assert len(charsets.EMOJI) == 40
+
+
+def test_german_umlauts():
+    assert "Ä" in charsets.GERMAN_UPPER
+    assert "ß" in charsets.GERMAN_LOWER
+
+
+def test_french_cedilla():
+    assert "ç" in charsets.FRENCH_LOWER
+
+
+def test_arabic_has_no_ascii():
+    assert not any('a' <= c <= 'z' or 'A' <= c <= 'Z' for c in charsets.ARABIC)
+
+
+def test_chinese_contains_common_character():
+    assert "的" in charsets.CHINESE
+
+
+def test_japanese_contains_scripts():
+    assert "あ" in charsets.JAPANESE
+    assert "ア" in charsets.JAPANESE


### PR DESCRIPTION
## Summary
- provide built-in charsets in `darkling/charsets.py`
- document charsets usage in `darkling/README.md`
- test predefined charsets

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687d1fa8cfb08326bdad16e3407b64b0