### PR TITLE
Enhance darkling mask handling

### DIFF
--- a/Worker/hashmancer_worker/gpu_sidecar.py
+++ b/Worker/hashmancer_worker/gpu_sidecar.py
@@ -189,6 +189,16 @@ class GPUSidecar(threading.Thread):
                 )
                 wordlist_path = str(tmp)
 
+        mask_charsets = batch.get("mask_charsets")
+        if mask_charsets:
+            try:
+                cs_map = json.loads(mask_charsets)
+            except Exception:
+                cs_map = {}
+            for key, charset in sorted(cs_map.items()):
+                if key.startswith("?") and len(key) == 2 and key[1].isdigit():
+                    cmd += [f"-{key[1]}", charset]
+
         if attack == "mask" and batch.get("mask"):
             cmd += ["-a", "3", batch["mask"]]
         elif attack == "dict" and wordlist_path:

--- a/tests/test_orchestrator_agent.py
+++ b/tests/test_orchestrator_agent.py
@@ -4,6 +4,7 @@ import sys
 ROOT = os.path.dirname(os.path.dirname(__file__))
 sys.path.insert(0, ROOT)
 sys.path.insert(0, os.path.join(ROOT, "Server"))
+import json
 
 import orchestrator_agent
 
@@ -41,4 +42,55 @@ def test_pending_count_create_group(monkeypatch):
     monkeypatch.setattr(orchestrator_agent, "r", fake)
     assert orchestrator_agent.pending_count() == 0
     assert fake.group_created
+
+
+def test_darkling_transformed_mask(monkeypatch, tmp_path):
+    wl = tmp_path / "wl.txt"
+    wl.write_text("Abc\n1234\n")
+
+    class DR(FakeRedis):
+        def __init__(self):
+            super().__init__()
+            self.jobs = {}
+            self.store = {"batch:1": {"hashes": "[]", "wordlist": str(wl)}}
+            self.queue = ["1"]
+            self.queued = []
+
+        def rpop(self, key):
+            return self.queue.pop(0) if self.queue else None
+
+        def hgetall(self, key):
+            return self.store.get(key, {})
+
+        def hset(self, key, mapping=None, **kw):
+            self.jobs[key] = dict(mapping or {})
+
+        def expire(self, key, ttl):
+            pass
+
+        def xadd(self, stream, mapping):
+            self.queued.append((stream, mapping))
+
+        def scan_iter(self, pattern):
+            return []
+
+    fake = DR()
+
+    monkeypatch.setattr(orchestrator_agent, "r", fake)
+    monkeypatch.setattr(orchestrator_agent, "compute_backlog_target", lambda: 1)
+    monkeypatch.setattr(orchestrator_agent, "pending_count", lambda *a, **k: 0)
+    monkeypatch.setattr(orchestrator_agent, "any_darkling_workers", lambda: True)
+    monkeypatch.setattr(orchestrator_agent, "cache_wordlist", lambda p: "key")
+    monkeypatch.setattr(orchestrator_agent, "generate_mask", lambda length: "$U$l$d$s")
+
+    orchestrator_agent.dispatch_batches()
+
+    stream, mapping = fake.queued[-1]
+    job = fake.jobs[f"job:{mapping['job_id']}"]
+
+    assert stream == orchestrator_agent.LOW_BW_JOB_STREAM
+    assert job["attack_mode"] == "mask"
+    assert job["mask"] == "?1?2?3?4"
+    cs = json.loads(job["mask_charsets"])
+    assert "?1" in cs and "?2" in cs and "?3" in cs and "?4" in cs
 


### PR DESCRIPTION
## Summary
- generate custom masks for darkling workers using pattern statistics
- send charset mappings with transformed jobs
- have workers pass custom charsets to darkling
- test new orchestrator and worker behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d293ffcac83268984c605122728c8