### PR TITLE
Add digits and ASCII helper constants

### DIFF
--- a/darkling/charsets.py
+++ b/darkling/charsets.py
@@ -9,10 +9,19 @@ EMOJI = (
 # Fifteen most common special characters
 COMMON_SYMBOLS = "!@#$%^&*()-=+[]"
 
+# Digits 0-9
+DIGITS = "0123456789"
+
 # Uppercase and lowercase alphabets for major languages
 
 ENGLISH_UPPER = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 ENGLISH_LOWER = "abcdefghijklmnopqrstuvwxyz"
+
+# ASCII helper sets
+ASCII_UPPER = ENGLISH_UPPER
+ASCII_LOWER = ENGLISH_LOWER
+ASCII_UPPER_LOWER = ENGLISH_UPPER + ENGLISH_LOWER
+ASCII_ALPHANUMERIC = ASCII_UPPER_LOWER + DIGITS
 
 SPANISH_UPPER = "AÁBCDEÉFGHIÍJKLMNÑOÓPQRSTUÚÜVWXYZ"
 SPANISH_LOWER = "aábcdeéfghiíjklmnñoópqrstuúüvwxyz"

--- a/tests/test_charsets.py
+++ b/tests/test_charsets.py
@@ -17,6 +17,18 @@ def test_emoji_only_symbols():
     assert len(charsets.EMOJI) == 40
 
 
+def test_digits_constant():
+    assert charsets.DIGITS == "0123456789"
+    assert len(charsets.DIGITS) == 10
+
+
+def test_ascii_upper_lower_constant():
+    assert (
+        charsets.ASCII_UPPER_LOWER
+        == charsets.ENGLISH_UPPER + charsets.ENGLISH_LOWER
+    )
+
+
 def test_german_umlauts():
     assert "Ä" in charsets.GERMAN_UPPER
     assert "ß" in charsets.GERMAN_LOWER


### PR DESCRIPTION
## Summary
- add `DIGITS` constant
- provide helper ASCII sets derived from `ENGLISH_UPPER` and `ENGLISH_LOWER`
- test new constants

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d2b3f5a4883268b8f73d149f9ebc7