### PR TITLE
Add darkling job range support

### DIFF
--- a/Server/orchestrator_agent.py
+++ b/Server/orchestrator_agent.py
@@ -172,6 +172,8 @@ def dispatch_batches():
             # route job depending on attack type
             if attack == "mask" and darkling and pending_low < backlog_target:
                 task_id = str(uuid.uuid4())
+                job_data["start"] = 0
+                job_data["end"] = 1000
                 r.hset(f"job:{task_id}", mapping=job_data)
                 r.expire(f"job:{task_id}", 3600)
                 r.xadd(LOW_BW_JOB_STREAM, {"job_id": task_id})
@@ -215,6 +217,8 @@ def dispatch_batches():
                     "wordlist_key": "",
                     "attack_mode": "mask",
                     "mask_charsets": json.dumps(ID_TO_CHARSET),
+                    "start": 0,
+                    "end": 1000,
                 })
                 r.hset(f"job:{d_id}", mapping=transformed)
                 r.expire(f"job:{d_id}", 3600)

--- a/Worker/hashmancer_worker/gpu_sidecar.py
+++ b/Worker/hashmancer_worker/gpu_sidecar.py
@@ -160,7 +160,9 @@ class GPUSidecar(threading.Thread):
 
         self.current_job = None
 
-    def _run_engine(self, engine: str, batch: dict) -> list[str]:
+    def _run_engine(
+        self, engine: str, batch: dict, range_start: int | None = None, range_end: int | None = None
+    ) -> list[str]:
         """Execute the given cracking engine according to the batch parameters."""
         batch_id = batch["batch_id"]
         hashes = json.loads(batch.get("hashes", "[]"))
@@ -205,6 +207,12 @@ class GPUSidecar(threading.Thread):
             cmd += ["-a", "0", wordlist_path]
         elif attack == "hybrid" and wordlist_path and batch.get("mask"):
             cmd += ["-a", "6", wordlist_path, batch["mask"]]
+
+        if engine == "darkling-engine":
+            if range_start is not None:
+                cmd += ["--start", str(range_start)]
+            if range_end is not None:
+                cmd += ["--end", str(range_end)]
 
         cmd += [
             "--quiet",
@@ -303,5 +311,10 @@ class GPUSidecar(threading.Thread):
         installed separately. It accepts the same arguments as hashcat so the
         batch formatting is identical.
         """
-        return self._run_engine("darkling-engine", batch)
+        return self._run_engine(
+            "darkling-engine",
+            batch,
+            range_start=batch.get("start"),
+            range_end=batch.get("end"),
+        )
 

--- a/darkling/darkling_host.cpp
+++ b/darkling/darkling_host.cpp
@@ -141,14 +141,23 @@ struct DarklingContext {
     }
 };
 
-int main() {
+int main(int argc, char** argv) {
+    uint64_t start = 0;
+    uint64_t end = 1000;
+    for (int i = 1; i < argc; ++i) {
+        if (std::strcmp(argv[i], "--start") == 0 && i + 1 < argc) {
+            start = std::strtoull(argv[++i], nullptr, 10);
+        } else if (std::strcmp(argv[i], "--end") == 0 && i + 1 < argc) {
+            end = std::strtoull(argv[++i], nullptr, 10);
+        }
+    }
     DarklingContext ctx;
     ctx.allocate_buffers(10);
     std::vector<std::string> charsets = {"abc", "123"};
     std::vector<uint8_t> pos_map = {0,1};
     std::vector<uint8_t> hashes(16); // placeholder
     ctx.preload(charsets, pos_map, hashes, 2, 16);
-    auto res = ctx.run(0, 1000);
+    auto res = ctx.run(start, end);
     for (auto& s : res) std::cout << s << "\n";
     return 0;
 }

--- a/tests/test_gpu_sidecar.py
+++ b/tests/test_gpu_sidecar.py
@@ -112,11 +112,15 @@ def test_darkling_engine_selected(monkeypatch):
         "mask": "?a",
         "attack_mode": "mask",
         "hash_mode": "0",
+        "start": 0,
+        "end": 1000,
     }
 
     sidecar.execute_job(batch)
 
     assert captured["cmd"][0] == "darkling-engine"
+    assert "--start" in captured["cmd"] and "0" in captured["cmd"]
+    assert "--end" in captured["cmd"] and "1000" in captured["cmd"]
 
 
 def test_custom_mask_charsets(monkeypatch):

--- a/tests/test_orchestrator_agent.py
+++ b/tests/test_orchestrator_agent.py
@@ -93,4 +93,6 @@ def test_darkling_transformed_mask(monkeypatch, tmp_path):
     assert job["mask"] == "?1?2?3?4"
     cs = json.loads(job["mask_charsets"])
     assert "?1" in cs and "?2" in cs and "?3" in cs and "?4" in cs
+    assert job["start"] == 0
+    assert job["end"] == 1000
 


### PR DESCRIPTION
## Summary
- include `start` and `end` fields when dispatching darkling jobs
- pass range options from `GPUSidecar` to `darkling-engine`
- parse `--start` and `--end` in `darkling_host.cpp`
- update tests for new range handling

## Testing
- `pip install -q -r Worker/requirements.txt -r Server/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d2c9cdad08326a486f430d082c5af