### PR TITLE
Handle emoji and common symbol tokens

### DIFF
--- a/Server/pattern_stats.py
+++ b/Server/pattern_stats.py
@@ -12,8 +12,8 @@ import redis
 from redis_utils import get_redis
 from pattern_utils import word_to_pattern, is_valid_word
 
-# pattern tokens are produced by word_to_pattern as "$U", "$l", "$d", "$s"
-TOKEN_RE = re.compile(r"\$[Ulds]")
+# pattern tokens are produced by word_to_pattern
+TOKEN_RE = re.compile(r"\$[Uldsce]")
 
 
 def update_stats(directory: Path) -> None:

--- a/Server/pattern_utils.py
+++ b/Server/pattern_utils.py
@@ -4,13 +4,16 @@ from __future__ import annotations
 
 import re
 
+from darkling import charsets
+
 
 def word_to_pattern(word: str) -> str:
     """Return a simplified hashcat-style pattern for *word*.
 
-    Each character is mapped to one of four symbols:
+    Each character is mapped to one of six symbols:
     ``$U`` for uppercase letters, ``$l`` for lowercase letters,
-    ``$d`` for digits and ``$s`` for symbols/other characters.
+    ``$d`` for digits, ``$c`` for common symbols,
+    ``$e`` for emoji and ``$s`` for other characters.
     """
     pattern = []
     for ch in word:
@@ -20,12 +23,16 @@ def word_to_pattern(word: str) -> str:
             pattern.append("$l")
         elif ch.isdigit():
             pattern.append("$d")
+        elif ch in charsets.COMMON_SYMBOLS:
+            pattern.append("$c")
+        elif ch in charsets.EMOJI:
+            pattern.append("$e")
         else:
             pattern.append("$s")
     return "".join(pattern)
 
 
-MASK_RE = re.compile(r"(?:\$[Ulds])+")
+MASK_RE = re.compile(r"(?:\$[Uldsce])+")
 
 
 def is_valid_pattern(mask: str) -> bool:

--- a/darkling/charsets.py
+++ b/darkling/charsets.py
@@ -1,5 +1,7 @@
 """Predefined character sets for the darkling engine."""
 
+import string
+
 # Emoji-only character set
 EMOJI = (
     "😀😁😂🤣😃😄😅😆😉😊😋😎😍😘🥰😗😙😚🙂🤗"
@@ -8,6 +10,9 @@ EMOJI = (
 
 # Fifteen most common special characters
 COMMON_SYMBOLS = "!@#$%^&*()-=+[]"
+
+# All printable ASCII symbols
+ALL_SYMBOLS = string.punctuation
 
 # Digits 0-9
 DIGITS = "0123456789"

--- a/tests/test_pattern_utils.py
+++ b/tests/test_pattern_utils.py
@@ -9,7 +9,11 @@ from Server.pattern_utils import word_to_pattern, is_valid_pattern, is_valid_wor
 
 
 def test_word_to_pattern():
-    assert word_to_pattern("Dark12!") == "$U$l$l$l$d$d$s"
+    assert word_to_pattern("Dark12!") == "$U$l$l$l$d$d$c"
+
+
+def test_word_to_pattern_common_symbol_and_emoji():
+    assert word_to_pattern("!😀") == "$c$e"
 
 
 def test_is_valid_pattern():
@@ -17,6 +21,10 @@ def test_is_valid_pattern():
     assert is_valid_pattern(pattern)
     assert not is_valid_pattern("$Ulldds")
     assert not is_valid_pattern("invalid")
+
+
+def test_is_valid_pattern_with_new_tokens():
+    assert is_valid_pattern("$c$e")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- extend `word_to_pattern` to classify common symbols and emoji
- add `ALL_SYMBOLS` constant in `charsets`
- support `$c` and `$e` tokens in regexes
- test new token handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d314304708326b1616126eabddd5b