### PR TITLE
Add --lang launcher for darkling demo

### DIFF
--- a/darkling/README.md
+++ b/darkling/README.md
@@ -27,6 +27,13 @@ g++ darkling_host.cpp -o darkling-host -lcuda -lcudart
 It preloads the kernel data into GPU memory and invokes `launch_darkling` across
 multiple counter ranges without re-allocating buffers.
 
+The `launcher.py` script wraps the binary and selects built-in alphabets
+for convenience. Use `--lang` to map `?1`/`?2` to a specific language:
+
+```
+python launcher.py --lang German --start 0 --end 1000
+```
+
 ## Tuning
 
 When run as part of the worker each GPU receives its own darkling instance.

--- a/darkling/darkling_host.cpp
+++ b/darkling/darkling_host.cpp
@@ -144,16 +144,31 @@ struct DarklingContext {
 int main(int argc, char** argv) {
     uint64_t start = 0;
     uint64_t end = 1000;
+    std::string cs_args[16];
+
     for (int i = 1; i < argc; ++i) {
         if (std::strcmp(argv[i], "--start") == 0 && i + 1 < argc) {
             start = std::strtoull(argv[++i], nullptr, 10);
         } else if (std::strcmp(argv[i], "--end") == 0 && i + 1 < argc) {
             end = std::strtoull(argv[++i], nullptr, 10);
+        } else if (argv[i][0] == '-' && std::isdigit(argv[i][1]) &&
+                   argv[i][2] == '\0' && i + 1 < argc) {
+            int id = argv[i][1] - '1';
+            if (id >= 0 && id < 16) {
+                cs_args[id] = argv[++i];
+            }
         }
     }
+
     DarklingContext ctx;
     ctx.allocate_buffers(10);
-    std::vector<std::string> charsets = {"abc", "123"};
+
+    std::vector<std::string> charsets;
+    if (!cs_args[0].empty()) charsets.push_back(cs_args[0]);
+    else charsets.push_back("abc");
+    if (!cs_args[1].empty()) charsets.push_back(cs_args[1]);
+    else charsets.push_back("123");
+
     std::vector<uint8_t> pos_map = {0,1};
     std::vector<uint8_t> hashes(16); // placeholder
     ctx.preload(charsets, pos_map, hashes, 2, 16);

--- a/darkling/launcher.py
+++ b/darkling/launcher.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+"""Simple launcher for the darkling demo kernel."""
+import argparse
+import subprocess
+from darkling import charsets
+
+
+def get_lang_sets(name: str) -> tuple[str, str]:
+    key = name.replace("-", "_").upper()
+    upper = getattr(charsets, f"{key}_UPPER", charsets.ENGLISH_UPPER)
+    lower = getattr(charsets, f"{key}_LOWER", charsets.ENGLISH_LOWER)
+    return upper, lower
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Launch darkling-host with language charsets")
+    parser.add_argument("--lang", default="English", help="language for ?1/?2 alphabets")
+    parser.add_argument("extra", nargs=argparse.REMAINDER, help="additional options for darkling-host")
+    args = parser.parse_args()
+
+    upper, lower = get_lang_sets(args.lang)
+    cmd = ["./darkling-host", "-1", upper, "-2", lower] + args.extra
+    subprocess.run(cmd, check=False)
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- add command line charset parsing to `darkling_host.cpp`
- provide `launcher.py` helper that maps `--lang` to predefined alphabets
- document the new option in `darkling/README.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d34ea28fc8326b1dc833d2e2f2178