### PR TITLE
Implement darkling benchmark helper

### DIFF
--- a/Worker/hashmancer_worker/worker_agent.py
+++ b/Worker/hashmancer_worker/worker_agent.py
@@ -9,7 +9,11 @@ from pathlib import Path
 import glob
 import socket
 
-from .gpu_sidecar import GPUSidecar, run_hashcat_benchmark
+from .gpu_sidecar import (
+    GPUSidecar,
+    run_hashcat_benchmark,
+    run_darkling_benchmark,
+)
 from .bios_flasher import GPUFlashManager
 from .crypto_utils import load_public_key_pem, sign_message
 from ascii_logo import print_logo
@@ -232,7 +236,9 @@ def main():
         engine = "hashcat"
         if gpu.get("pci_link_width", gpu.get("pci_width", 16)) <= 4 and low_bw_engine == "darkling":
             engine = "darkling-engine"
-        rates = run_hashcat_benchmark(gpu, engine)
+            rates = run_darkling_benchmark(gpu)
+        else:
+            rates = run_hashcat_benchmark(gpu, engine)
         payload = {
             "worker_id": name,
             "gpu_uuid": gpu.get("uuid"),

--- a/tests/test_gpu_sidecar.py
+++ b/tests/test_gpu_sidecar.py
@@ -380,3 +380,19 @@ def test_run_hashcat_benchmark(monkeypatch):
     rates = gpu_sidecar.run_hashcat_benchmark(gpu)
     assert rates == {"MD5": 10.0e6, "SHA1": 20.0e6, "NTLM": 30.0e6}
 
+
+def test_run_darkling_benchmark(monkeypatch):
+    def fake_popen(cmd, stdout=None, stderr=None, text=None):
+        mode = int(cmd[cmd.index("-m") + 1])
+        if mode == 0:
+            return DummyProc(["{\"speed\": [10]}"], "/tmp/db1.out")
+        if mode == 100:
+            return DummyProc(["{\"speed\": [20]}"], "/tmp/db2.out")
+        raise Exception("unsupported")
+
+    monkeypatch.setattr(gpu_sidecar.subprocess, "Popen", fake_popen)
+
+    gpu = {"uuid": "gpu", "index": 0}
+    rates = gpu_sidecar.run_darkling_benchmark(gpu)
+    assert rates == {"MD5": 10.0, "SHA1": 20.0, "NTLM": 0.0}
+


### PR DESCRIPTION
## Summary
- add `run_darkling_benchmark` to measure darkling engine speed
- call this helper when benchmarking low-bandwidth GPUs
- test new benchmark logic

## Testing
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d4612a1988326b14aeaff20e0ab08