### PR TITLE
Integrate Hashes.com polling

### DIFF
--- a/Server/hashescom_client.py
+++ b/Server/hashescom_client.py
@@ -1,7 +1,23 @@
 import requests
 import os
+import json
+from pathlib import Path
 
-HASHES_API = os.environ.get("HASHES_COM_API_KEY")
+# Prefer an environment variable but fall back to the server config
+CONFIG_FILE = Path.home() / ".hashmancer" / "server_config.json"
+
+def _load_api_key() -> str | None:
+    key = os.environ.get("HASHES_COM_API_KEY")
+    if key:
+        return key
+    try:
+        with CONFIG_FILE.open() as f:
+            cfg = json.load(f)
+        return cfg.get("hashes_api_key")
+    except Exception:
+        return None
+
+HASHES_API = _load_api_key()
 
 
 def fetch_jobs():

--- a/Server/portal.html
+++ b/Server/portal.html
@@ -110,6 +110,18 @@ body::before {
 <tbody id="job-body"></tbody></table>
 </section>
 
+<section id="hashes-settings">
+<h2>Hashes.com Settings</h2>
+<div>API Key: <input type="password" id="hashes-key"><button onclick="saveHashesKey()">Save</button></div>
+<div>Algorithms: <input type="text" id="hashes-algos"><button onclick="saveHashesAlgos()">Save</button></div>
+</section>
+
+<section id="hashes-jobs">
+<h2>Hashes.com Jobs</h2>
+<button onclick="loadHashesJobs()">Refresh</button>
+<pre id="hashes-job-output"></pre>
+</section>
+
 <script>
 function applyMetrics(data){
   document.getElementById('workers').textContent = data.worker_count;
@@ -275,6 +287,23 @@ async function loadJobs(){
   }
 }
 
+async function saveHashesKey(){
+  const key=document.getElementById('hashes-key').value.trim();
+  await fetch('/hashes_api_key',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({api_key:key})});
+}
+
+async function saveHashesAlgos(){
+  const txt=document.getElementById('hashes-algos').value.trim();
+  const algos=txt?txt.split(',').map(a=>a.trim()):[];
+  await fetch('/hashes_algorithms',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({algorithms:algos})});
+}
+
+async function loadHashesJobs(){
+  const res=await fetch('/hashes_jobs');
+  const jobs=await res.json();
+  document.getElementById('hashes-job-output').textContent=JSON.stringify(jobs,null,2);
+}
+
 function tick(){
   loadDicts();
   loadMasks();
@@ -282,6 +311,7 @@ function tick(){
   loadWorkers();
   loadJobs();
   loadLogs();
+  loadHashesJobs();
 }
 
 function startWS(){

--- a/tests/test_hashes_poll.py
+++ b/tests/test_hashes_poll.py
@@ -1,0 +1,86 @@
+import asyncio
+import sys
+import types
+
+fastapi_stub = types.ModuleType('fastapi')
+class FakeApp:
+    def add_middleware(self, *a, **kw):
+        pass
+    def on_event(self, *a, **kw):
+        return lambda f: f
+    def post(self, *a, **kw):
+        return lambda f: f
+    def get(self, *a, **kw):
+        return lambda f: f
+    def delete(self, *a, **kw):
+        return lambda f: f
+    def websocket(self, *a, **kw):
+        return lambda f: f
+fastapi_stub.FastAPI = lambda: FakeApp()
+fastapi_stub.UploadFile = object
+fastapi_stub.File = lambda *a, **kw: None
+fastapi_stub.WebSocket = object
+fastapi_stub.WebSocketDisconnect = type('WebSocketDisconnect', (), {})
+class HTTPException(Exception):
+    pass
+fastapi_stub.HTTPException = HTTPException
+sys.modules.setdefault('fastapi', fastapi_stub)
+
+cors_stub = types.ModuleType('fastapi.middleware.cors')
+cors_stub.CORSMiddleware = object
+sys.modules.setdefault('fastapi.middleware.cors', cors_stub)
+
+resp_stub = types.ModuleType('fastapi.responses')
+resp_stub.HTMLResponse = object
+sys.modules.setdefault('fastapi.responses', resp_stub)
+
+pydantic_stub = types.ModuleType('pydantic')
+class BaseModel:
+    pass
+pydantic_stub.BaseModel = BaseModel
+sys.modules.setdefault('pydantic', pydantic_stub)
+
+crypto_stub = types.ModuleType('cryptography')
+exc_stub = types.ModuleType('cryptography.exceptions')
+class InvalidSignature(Exception):
+    pass
+exc_stub.InvalidSignature = InvalidSignature
+prim_stub = types.ModuleType('cryptography.hazmat.primitives')
+prim_stub.asymmetric = types.SimpleNamespace(padding=object())
+prim_stub.hashes = types.SimpleNamespace(SHA256=lambda: None)
+prim_stub.serialization = types.SimpleNamespace(load_pem_public_key=lambda x: None)
+crypto_stub.hazmat = types.SimpleNamespace(primitives=prim_stub)
+crypto_stub.exceptions = exc_stub
+sys.modules.setdefault('cryptography', crypto_stub)
+sys.modules.setdefault('cryptography.exceptions', exc_stub)
+sys.modules.setdefault('cryptography.hazmat.primitives', prim_stub)
+sys.modules.setdefault('cryptography.hazmat.primitives.asymmetric', prim_stub.asymmetric)
+
+sys.path.insert(0, '..')
+sys.path.insert(0, 'Server')
+import main
+import hashescom_client
+
+class FakeRedis:
+    def __init__(self):
+        self.store = {}
+    def hset(self, key, mapping=None, **kwargs):
+        self.store.setdefault(key, {}).update(mapping or {})
+    def scan_iter(self, pattern):
+        return []
+
+async def run_once():
+    await main.fetch_and_store_jobs()
+
+def test_fetch_and_store_jobs(monkeypatch):
+    fake = FakeRedis()
+    monkeypatch.setattr(main, 'r', fake)
+    monkeypatch.setattr(main, 'HASHES_ALGORITHMS', ['md5'])
+    monkeypatch.setattr(hashescom_client, 'fetch_jobs', lambda: [{
+        'id': 8,
+        'algorithmName': 'MD5',
+        'currency': 'BTC',
+        'pricePerHash': '1'
+    }])
+    asyncio.run(run_once())
+    assert 'hashes_job:8' in fake.store


### PR DESCRIPTION
## Summary
- poll Hashes.com every 30 minutes and store jobs in Redis
- expose API key/algorithm settings via new endpoints
- add hashes.com sections in portal UI
- support API key retrieval from server config
- cover job polling with new test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d54e29a48832698e7efddf6d6ed8b