### PR TITLE
Add flash tuning utility

### DIFF
--- a/Server/flash_presets.json
+++ b/Server/flash_presets.json
@@ -1,0 +1,25 @@
+{
+    "nvidia": {
+        "rtx 3080": {"power_limit": 220, "core_clock": 1350, "mem_clock": 4500},
+        "rtx 3070": {"power_limit": 180, "core_clock": 1200, "mem_clock": 4000},
+        "gtx 1050": {"power_limit": 60, "core_clock": 1350, "mem_clock": 3500},
+        "gtx 1050 ti": {"power_limit": 70, "core_clock": 1400, "mem_clock": 3500},
+        "gtx 1060": {"power_limit": 90, "core_clock": 1500, "mem_clock": 4000},
+        "gtx 1070": {"power_limit": 110, "core_clock": 1600, "mem_clock": 4200},
+        "gtx 1080": {"power_limit": 140, "core_clock": 1700, "mem_clock": 4800},
+        "gtx 1080 ti": {"power_limit": 180, "core_clock": 1700, "mem_clock": 5000},
+        "gtx 2080": {"power_limit": 170, "core_clock": 1800, "mem_clock": 6500},
+        "gtx 2080 ti": {"power_limit": 200, "core_clock": 1800, "mem_clock": 7000},
+        "default": {"power_limit": 150, "core_clock": 1100, "mem_clock": 3000}
+    },
+    "amd": {
+        "rx 6800": {"power_limit": 170, "core_clock": 1200, "mem_clock": 2100},
+        "rx 6700": {"power_limit": 150, "core_clock": 1100, "mem_clock": 1900},
+        "rx 470": {"power_limit": 110, "core_clock": 1200, "mem_clock": 1750},
+        "rx 480": {"power_limit": 120, "core_clock": 1250, "mem_clock": 1750},
+        "rx 570": {"power_limit": 110, "core_clock": 1200, "mem_clock": 1750},
+        "rx 580": {"power_limit": 125, "core_clock": 1250, "mem_clock": 2000},
+        "default": {"power_limit": 120, "core_clock": 1000, "mem_clock": 1800}
+    }
+}
+

--- a/Server/main.py
+++ b/Server/main.py
@@ -75,18 +75,38 @@ def save_config():
         log_error("server", "system", "S740", "Failed to save config", e)
 
 # baseline undervolt/flash settings per GPU model
-FLASH_PRESETS = {
-    "nvidia": {
-        "rtx 3080": {"power_limit": 220, "core_clock": 1350, "mem_clock": 4500},
-        "rtx 3070": {"power_limit": 180, "core_clock": 1200, "mem_clock": 4000},
-        "default": {"power_limit": 150, "core_clock": 1100, "mem_clock": 3000},
-    },
-    "amd": {
-        "rx 6800": {"power_limit": 170, "core_clock": 1200, "mem_clock": 2100},
-        "rx 6700": {"power_limit": 150, "core_clock": 1100, "mem_clock": 1900},
-        "default": {"power_limit": 120, "core_clock": 1000, "mem_clock": 1800},
-    },
-}
+FLASH_PRESETS_FILE = Path(__file__).with_name("flash_presets.json")
+if FLASH_PRESETS_FILE.exists():
+    try:
+        with FLASH_PRESETS_FILE.open() as f:
+            FLASH_PRESETS = json.load(f)
+    except Exception:
+        FLASH_PRESETS = {}
+else:
+    FLASH_PRESETS = {
+        "nvidia": {
+            "rtx 3080": {"power_limit": 220, "core_clock": 1350, "mem_clock": 4500},
+            "rtx 3070": {"power_limit": 180, "core_clock": 1200, "mem_clock": 4000},
+            "gtx 1050": {"power_limit": 60, "core_clock": 1350, "mem_clock": 3500},
+            "gtx 1050 ti": {"power_limit": 70, "core_clock": 1400, "mem_clock": 3500},
+            "gtx 1060": {"power_limit": 90, "core_clock": 1500, "mem_clock": 4000},
+            "gtx 1070": {"power_limit": 110, "core_clock": 1600, "mem_clock": 4200},
+            "gtx 1080": {"power_limit": 140, "core_clock": 1700, "mem_clock": 4800},
+            "gtx 1080 ti": {"power_limit": 180, "core_clock": 1700, "mem_clock": 5000},
+            "gtx 2080": {"power_limit": 170, "core_clock": 1800, "mem_clock": 6500},
+            "gtx 2080 ti": {"power_limit": 200, "core_clock": 1800, "mem_clock": 7000},
+            "default": {"power_limit": 150, "core_clock": 1100, "mem_clock": 3000},
+        },
+        "amd": {
+            "rx 6800": {"power_limit": 170, "core_clock": 1200, "mem_clock": 2100},
+            "rx 6700": {"power_limit": 150, "core_clock": 1100, "mem_clock": 1900},
+            "rx 470": {"power_limit": 110, "core_clock": 1200, "mem_clock": 1750},
+            "rx 480": {"power_limit": 120, "core_clock": 1250, "mem_clock": 1750},
+            "rx 570": {"power_limit": 110, "core_clock": 1200, "mem_clock": 1750},
+            "rx 580": {"power_limit": 125, "core_clock": 1250, "mem_clock": 2000},
+            "default": {"power_limit": 120, "core_clock": 1000, "mem_clock": 1800},
+        },
+    }
 
 
 def get_flash_settings(model: str) -> dict:

--- a/Worker/README.md
+++ b/Worker/README.md
@@ -95,4 +95,10 @@ the settings the worker first uses `nvflash_linux` (for NVIDIA) or `amdvbflash`
 for AMD GPUs to dump the existing ROM.  Should flashing fail the backup ROM is
 flashed back automatically.  PCI addresses are detected with `lspci` or vendor
 utilities so the correct adapter is selected.
+The server reads baseline clock/power presets from
+`Server/flash_presets.json`. Edit this file to add or modify GPU models as
+needed. A helper script `flash_tuner.py` can be used to test flashing locally
+and reduce the power limit in small steps while verifying stability. Run it with
+`python -m hashmancer_worker.flash_tuner --index 0 --vendor nvidia --model "RTX
+3080"` for example.
 

--- a/Worker/hashmancer_worker/flash_tuner.py
+++ b/Worker/hashmancer_worker/flash_tuner.py
@@ -1,0 +1,68 @@
+import argparse
+import json
+from pathlib import Path
+
+from .bios_flasher import apply_flash_settings, md5_speed
+
+PRESETS_FILE = Path(__file__).resolve().parents[2] / "Server" / "flash_presets.json"
+
+
+def load_presets() -> dict:
+    if PRESETS_FILE.exists():
+        try:
+            with open(PRESETS_FILE) as f:
+                return json.load(f)
+        except Exception:
+            return {}
+    return {}
+
+
+def tune_power_limit(index: int, vendor: str, preset: dict) -> int:
+    """Iteratively lower power_limit until performance drops."""
+    baseline = md5_speed()
+    power = int(preset.get("power_limit", 0))
+    best = power
+    step = 5
+    while power >= 0:
+        settings = {
+            "vendor": vendor,
+            "power_limit": power,
+            "core_clock": preset.get("core_clock"),
+            "mem_clock": preset.get("mem_clock"),
+        }
+        success = apply_flash_settings({"index": index}, settings)
+        post = md5_speed() if success else 0
+        if not success or post < baseline * 0.8:
+            break
+        best = power
+        power -= step
+    if best != int(preset.get("power_limit", 0)):
+        apply_flash_settings(
+            {"index": index},
+            {
+                "vendor": vendor,
+                "power_limit": best,
+                "core_clock": preset.get("core_clock"),
+                "mem_clock": preset.get("mem_clock"),
+            },
+        )
+    return best
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Tune GPU power limit")
+    parser.add_argument("--index", type=int, default=0, help="GPU index")
+    parser.add_argument("--vendor", choices=["nvidia", "amd"], default="nvidia")
+    parser.add_argument("--model", type=str, help="GPU model name")
+    args = parser.parse_args()
+
+    presets = load_presets().get(args.vendor, {})
+    model = (args.model or "").lower()
+    preset = presets.get(model, presets.get("default", {}))
+    best = tune_power_limit(args.index, args.vendor, preset)
+    print(f"Stable power limit: {best}")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/tests/test_flash_tuner.py
+++ b/tests/test_flash_tuner.py
@@ -1,0 +1,22 @@
+import sys
+import os
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from Worker.hashmancer_worker import flash_tuner
+
+
+def test_tune_power_limit(monkeypatch):
+    seq = iter([1.0, 0.95, 0.95, 0.75])
+    monkeypatch.setattr(flash_tuner, "md5_speed", lambda: next(seq))
+    applied = []
+
+    def fake_apply(gpu, settings):
+        applied.append(settings["power_limit"])
+        return True
+
+    monkeypatch.setattr(flash_tuner, "apply_flash_settings", fake_apply)
+    preset = {"power_limit": 100, "core_clock": 1500, "mem_clock": 4000}
+    best = flash_tuner.tune_power_limit(0, "nvidia", preset)
+    assert best == 95
+    assert applied == [100, 95, 90, 95]
+


### PR DESCRIPTION
## Summary
- add `flash_tuner.py` to test and tune GPU flashing presets
- document the tuner in the worker README
- test tuning logic in `test_flash_tuner.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d5bf2f14c832681f8afc47c6c13e1