### PR TITLE
Defer stream acknowledgement until job completion

### DIFF
--- a/Worker/hashmancer_worker/gpu_sidecar.py
+++ b/Worker/hashmancer_worker/gpu_sidecar.py
@@ -165,6 +165,8 @@ class GPUSidecar(threading.Thread):
             payload = {
                 "worker_id": self.worker_id,
                 "batch_id": batch_id,
+                "job_id": job_id,
+                "msg_id": batch.get("msg_id"),
                 "founds": founds,
                 "signature": sign_message(json.dumps(founds)),
             }
@@ -173,6 +175,8 @@ class GPUSidecar(threading.Thread):
             payload = {
                 "worker_id": self.worker_id,
                 "batch_id": batch_id,
+                "job_id": job_id,
+                "msg_id": batch.get("msg_id"),
                 "signature": sign_message(batch_id),
             }
             endpoint = "submit_no_founds"


### PR DESCRIPTION
## Summary
- include message and stream identifiers when assigning batches
- acknowledge jobs only after results submission
- propagate `job_id` and `msg_id` in worker payloads
- update tests for delayed acknowledgement

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d6f3314108326bf7093a941f25dff