### PR TITLE
Add HIP/OpenCL support for darkling engine

### DIFF
--- a/darkling/CMakeLists.txt
+++ b/darkling/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.10)
+project(darkling_backends LANGUAGES C CXX)
+
+option(ENABLE_CUDA "Build CUDA backend" ON)
+option(ENABLE_HIP "Build HIP backend" ON)
+option(ENABLE_OPENCL "Build OpenCL backend" ON)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+if(ENABLE_CUDA)
+  enable_language(CUDA)
+  add_library(cuda_backend STATIC cuda_backend/cuda_cracker.cu darkling_engine.cu)
+endif()
+
+if(ENABLE_HIP)
+  find_package(HIP REQUIRED)
+  hip_add_library(hip_backend STATIC hip_backend/hip_cracker.cpp hip_backend/darkling_engine.hip)
+endif()
+
+if(ENABLE_OPENCL)
+  find_package(OpenCL REQUIRED)
+  add_library(opencl_backend STATIC intel_backend/intel_cracker.cpp)
+  target_sources(opencl_backend PRIVATE intel_backend/opencl_kernel.cl)
+  target_link_libraries(opencl_backend PRIVATE OpenCL::OpenCL)
+endif()

--- a/darkling/README.md
+++ b/darkling/README.md
@@ -87,3 +87,19 @@ mask_charsets = {
 `charsets.py` exposes uppercase and lowercase alphabets for the top 20
 languages along with `COMMON_SYMBOLS`, `EMOJI`, and scripts such as
 `CHINESE` and `JAPANESE` for convenience.
+
+## Building the GPU Backends
+
+The CUDA implementation is built by default but HIP and OpenCL backends can
+also be compiled via CMake:
+
+```bash
+cd darkling
+cmake -DENABLE_HIP=ON -DENABLE_OPENCL=ON -B build
+cmake --build build
+```
+
+`ENABLE_CUDA`, `ENABLE_HIP`, and `ENABLE_OPENCL` may be toggled to target a
+specific platform.  The resulting static libraries `cuda_backend`,
+`hip_backend`, and `opencl_backend` expose a `launch_darkling` entry point for
+each vendor.

--- a/darkling/hip_backend/darkling_engine.hip
+++ b/darkling/hip_backend/darkling_engine.hip
@@ -1,0 +1,190 @@
+#include <stdint.h>
+#include <hip/hip_runtime.h>
+#include <stdio.h>
+
+#include "darkling_engine.h"
+
+// constant buffers for mask charsets and hashes
+__constant__ uint8_t d_charset_bytes[MAX_CUSTOM_SETS][MAX_CHARSET_CHARS][MAX_UTF8_BYTES];
+__constant__ uint8_t d_charset_charlen[MAX_CUSTOM_SETS][MAX_CHARSET_CHARS];
+__constant__ int  d_charset_lens[MAX_CUSTOM_SETS];
+__constant__ uint8_t d_pos_charset[MAX_MASK_LEN];
+__constant__ uint8_t d_hashes[MAX_HASHES][20];   // supports up to SHA1
+__constant__ int d_num_hashes;
+__constant__ int d_hash_len;  // digest length (16 for MD5, 20 for SHA1)
+__constant__ int d_pwd_len;
+
+__device__ inline uint32_t rotl32(uint32_t x, uint32_t n) {
+    return (x << n) | (x >> (32 - n));
+}
+
+// simple MD5 implementation for short inputs (<55 bytes)
+__device__ void md5(const char *msg, int len, uint8_t out[16]) {
+    const uint32_t init[4] = {0x67452301, 0xefcdab89, 0x98badcfe, 0x10325476};
+    uint32_t a = init[0], b = init[1], c = init[2], d = init[3];
+
+    uint8_t buffer[64];
+    for (int i=0;i<64;i++) buffer[i] = 0;
+    for (int i=0;i<len;i++) buffer[i] = (uint8_t)msg[i];
+    buffer[len] = 0x80;
+    uint64_t bits = (uint64_t)len * 8;
+    for (int i=0;i<8;i++) buffer[56+i] = (bits >> (8*i)) & 0xff;
+
+    const uint32_t k[] = {
+        0xd76aa478,0xe8c7b756,0x242070db,0xc1bdceee,0xf57c0faf,0x4787c62a,0xa8304613,0xfd469501,
+        0x698098d8,0x8b44f7af,0xffff5bb1,0x895cd7be,0x6b901122,0xfd987193,0xa679438e,0x49b40821,
+        0xf61e2562,0xc040b340,0x265e5a51,0xe9b6c7aa,0xd62f105d,0x02441453,0xd8a1e681,0xe7d3fbc8,
+        0x21e1cde6,0xc33707d6,0xf4d50d87,0x455a14ed,0xa9e3e905,0xfcefa3f8,0x676f02d9,0x8d2a4c8a,
+        0xfffa3942,0x8771f681,0x6d9d6122,0xfde5380c,0xa4beea44,0x4bdecfa9,0xf6bb4b60,0xbebfbc70,
+        0x289b7ec6,0xeaa127fa,0xd4ef3085,0x04881d05,0xd9d4d039,0xe6db99e5,0x1fa27cf8,0xc4ac5665,
+        0xf4292244,0x432aff97,0xab9423a7,0xfc93a039,0x655b59c3,0x8f0ccc92,0xffeff47d,0x85845dd1,
+        0x6fa87e4f,0xfe2ce6e0,0xa3014314,0x4e0811a1,0xf7537e82,0xbd3af235,0x2ad7d2bb,0xeb86d391
+    };
+    const uint32_t r[] = {
+        7,12,17,22,7,12,17,22,7,12,17,22,7,12,17,22,
+        5,9,14,20,5,9,14,20,5,9,14,20,5,9,14,20,
+        4,11,16,23,4,11,16,23,4,11,16,23,4,11,16,23,
+        6,10,15,21,6,10,15,21,6,10,15,21,6,10,15,21
+    };
+
+    uint32_t w[16];
+    for(int i=0;i<16;i++) {
+        w[i] = (uint32_t)buffer[i*4] | ((uint32_t)buffer[i*4+1]<<8) |
+               ((uint32_t)buffer[i*4+2]<<16) | ((uint32_t)buffer[i*4+3]<<24);
+    }
+    uint32_t aa=a, bb=b, cc=c, dd=d;
+    for(int i=0;i<64;i++) {
+        uint32_t f,g;
+        if(i<16)      { f=(b & c) | (~b & d); g=i; }
+        else if(i<32) { f=(d & b) | (~d & c); g=(5*i+1)&15; }
+        else if(i<48) { f=b ^ c ^ d; g=(3*i+5)&15; }
+        else          { f=c ^ (b | ~d); g=(7*i)&15; }
+        uint32_t temp=d; d=c; c=b;
+        uint32_t t=a + f + k[i] + w[g];
+        b += rotl32(t, r[i]);
+        a=temp;
+    }
+    a+=aa; b+=bb; c+=cc; d+=dd;
+    uint32_t out32[4]={a,b,c,d};
+    for(int i=0;i<4;i++){
+        out[i*4]=(out32[i])&0xff;
+        out[i*4+1]=(out32[i]>>8)&0xff;
+        out[i*4+2]=(out32[i]>>16)&0xff;
+        out[i*4+3]=(out32[i]>>24)&0xff;
+    }
+}
+
+// simple SHA1 implementation for short inputs (<56 bytes)
+__device__ void sha1(const char *msg, int len, uint8_t out[20]) {
+    uint32_t h0=0x67452301, h1=0xefcdab89, h2=0x98badcfe, h3=0x10325476, h4=0xc3d2e1f0;
+    uint8_t buffer[64];
+    for(int i=0;i<64;i++) buffer[i]=0;
+    for(int i=0;i<len;i++) buffer[i]=(uint8_t)msg[i];
+    buffer[len]=0x80;
+    uint64_t bits=(uint64_t)len*8;
+    for(int i=0;i<8;i++) buffer[56+i]=(bits>>(56-8*i))&0xff;
+    uint32_t w[80];
+    for(int i=0;i<16;i++) {
+        w[i]=((uint32_t)buffer[4*i]<<24)|((uint32_t)buffer[4*i+1]<<16)|((uint32_t)buffer[4*i+2]<<8)|buffer[4*i+3];
+    }
+    for(int i=16;i<80;i++) w[i]=rotl32(w[i-3]^w[i-8]^w[i-14]^w[i-16],1);
+    uint32_t a=h0,b=h1,c=h2,d=h3,e=h4;
+    for(int i=0;i<80;i++) {
+        uint32_t f,k;
+        if(i<20){f=(b&c)|((~b)&d);k=0x5a827999;}
+        else if(i<40){f=b^c^d;k=0x6ed9eba1;}
+        else if(i<60){f=(b&c)|(b&d)|(c&d);k=0x8f1bbcdc;}
+        else{f=b^c^d;k=0xca62c1d6;}
+        uint32_t temp=rotl32(a,5)+f+e+k+w[i];
+        e=d; d=c; c=rotl32(b,30); b=a; a=temp;
+    }
+    h0+=a; h1+=b; h2+=c; h3+=d; h4+=e;
+    uint32_t hv[5]={h0,h1,h2,h3,h4};
+    for(int i=0;i<5;i++){
+        out[i*4]=(hv[i]>>24)&0xff;
+        out[i*4+1]=(hv[i]>>16)&0xff;
+        out[i*4+2]=(hv[i]>>8)&0xff;
+        out[i*4+3]=hv[i]&0xff;
+    }
+}
+
+__device__ void compute_hash(const char *pwd, int len, uint8_t *out) {
+    if (d_hash_len == 16) md5(pwd, len, out);
+    else sha1(pwd, len, out);
+}
+
+__device__ bool check_hash(const uint8_t *digest) {
+    for (int h=0; h<d_num_hashes; ++h) {
+        bool match = true;
+        for(int i=0;i<d_hash_len;i++) {
+            if (digest[i] != d_hashes[h][i]) { match = false; break; }
+        }
+        if (match) return true;
+    }
+    return false;
+}
+
+__global__ void crack_kernel(uint64_t start, uint64_t total, char *results,
+                             int max_results, int *found_count) {
+    uint64_t idx = start + threadIdx.x + blockIdx.x * (uint64_t)blockDim.x;
+    uint64_t step = gridDim.x * (uint64_t)blockDim.x;
+    uint8_t pwd[MAX_PWD_BYTES];
+    uint8_t idx_buf[MAX_MASK_LEN];
+    uint8_t digest[20];
+
+    uint64_t end = start + total;
+    while (idx < end) {
+        uint64_t val = idx;
+        for (int pos = d_pwd_len - 1; pos >= 0; --pos) {
+            int set = d_pos_charset[pos];
+            int len = d_charset_lens[set];
+            idx_buf[pos] = val % len;
+            val /= len;
+        }
+        int out_len = 0;
+        for (int pos = 0; pos < d_pwd_len; ++pos) {
+            int set = d_pos_charset[pos];
+            int ci = idx_buf[pos];
+            int clen = d_charset_charlen[set][ci];
+            for (int j=0; j<clen; ++j)
+                pwd[out_len++] = d_charset_bytes[set][ci][j];
+        }
+        compute_hash((char*)pwd, out_len, digest);
+        if (check_hash(digest)) {
+            int slot = atomicAdd(found_count, 1);
+            if (slot < max_results) {
+                int off = slot*MAX_PWD_BYTES;
+                for(int i=0;i<out_len;i++) results[off+i] = pwd[i];
+                results[off+out_len] = '\0';
+            }
+        }
+        idx += step;
+    }
+}
+
+extern "C" void launch_darkling_hip(const uint8_t **charset_bytes,
+                                 const uint8_t **charset_lens,
+                                 const int *charset_sizes,
+                                 const uint8_t *pos_map, int pwd_len,
+                                 const uint8_t *hashes, int num_hashes, int hash_len,
+                                 uint64_t start, uint64_t end,
+                                 char *d_results, int max_results, int *d_count,
+                                 dim3 grid, dim3 block)
+{
+    hipMemcpyToSymbol(HIP_SYMBOL(d_pwd_len), &pwd_len, sizeof(int));
+    hipMemcpyToSymbol(HIP_SYMBOL(d_hash_len), &hash_len, sizeof(int));
+    hipMemcpyToSymbol(HIP_SYMBOL(d_num_hashes), &num_hashes, sizeof(int));
+    hipMemcpyToSymbol(HIP_SYMBOL(d_pos_charset), pos_map, pwd_len);
+    for(int i=0;i<MAX_CUSTOM_SETS; i++) {
+        hipMemcpyToSymbol(HIP_SYMBOL(d_charset_lens), &charset_sizes[i], sizeof(int), i*sizeof(int));
+        if(charset_sizes[i] > 0) {
+            hipMemcpyToSymbol(HIP_SYMBOL(d_charset_bytes), charset_bytes[i], charset_sizes[i]*MAX_UTF8_BYTES,
+                               i*MAX_CHARSET_CHARS*MAX_UTF8_BYTES);
+            hipMemcpyToSymbol(HIP_SYMBOL(d_charset_charlen), charset_lens[i], charset_sizes[i],
+                               i*MAX_CHARSET_CHARS);
+        }
+    }
+    hipMemcpyToSymbol(HIP_SYMBOL(d_hashes), hashes, num_hashes * hash_len);
+    uint64_t total = end - start;
+    hipLaunchKernelGGL(crack_kernel, grid, block, 0, 0, start, total, d_results, max_results, d_count);
+}

--- a/darkling/hip_backend/hip_cracker.cpp
+++ b/darkling/hip_backend/hip_cracker.cpp
@@ -1,4 +1,6 @@
 #include "hip_cracker.h"
+#include "darkling_engine.h"
+#include <hip/hip_runtime.h>
 #include <iostream>
 
 namespace darkling {
@@ -11,11 +13,51 @@ bool HipCracker::initialize() {
 }
 
 bool HipCracker::load_job(const MaskJob &job) {
-    (void)job;
+    job_ = job;
     return true;
 }
 
 bool HipCracker::run_batch() {
+    dim3 grid{64};
+    dim3 block{64};
+
+    static uint8_t cs_bytes[MAX_CUSTOM_SETS][MAX_CHARSET_CHARS][MAX_UTF8_BYTES];
+    static uint8_t cs_lens[MAX_CUSTOM_SETS][MAX_CHARSET_CHARS];
+    static int cs_sizes[MAX_CUSTOM_SETS];
+
+    for(int s=0;s<MAX_CUSTOM_SETS;s++){
+        int len=job_.charset_lengths[s];
+        cs_sizes[s]=len;
+        for(int i=0;i<len;i++){
+            cs_bytes[s][i][0]=job_.charsets[s][i];
+            cs_lens[s][i]=1;
+        }
+    }
+
+    const uint8_t* byte_ptrs[MAX_CUSTOM_SETS];
+    const uint8_t* len_ptrs[MAX_CUSTOM_SETS];
+    for(int i=0;i<MAX_CUSTOM_SETS;i++){
+        byte_ptrs[i]=&cs_bytes[i][0][0];
+        len_ptrs[i]=&cs_lens[i][0];
+    }
+
+    char* d_results=nullptr;
+    int* d_count=nullptr;
+    hipMalloc(&d_results, MAX_RESULT_BUFFER * MAX_PWD_BYTES);
+    hipMalloc(&d_count, sizeof(int));
+    hipMemset(d_count, 0, sizeof(int));
+
+    launch_darkling_hip(byte_ptrs, len_ptrs, cs_sizes,
+                        job_.mask_template, job_.mask_length,
+                        reinterpret_cast<const uint8_t*>(job_.hashes),
+                        job_.num_hashes, job_.hash_length,
+                        job_.start_index, job_.end_index,
+                        d_results, MAX_RESULT_BUFFER, d_count,
+                        grid, block);
+    hipDeviceSynchronize();
+
+    hipFree(d_results);
+    hipFree(d_count);
     return true;
 }
 

--- a/darkling/hip_backend/hip_cracker.h
+++ b/darkling/hip_backend/hip_cracker.h
@@ -15,6 +15,9 @@ public:
     bool run_batch() override;
     std::vector<CrackResult> read_results() override;
     GpuStatus get_status() override;
+
+private:
+    MaskJob job_{};
 };
 
 } // namespace darkling

--- a/darkling/intel_backend/intel_cracker.cpp
+++ b/darkling/intel_backend/intel_cracker.cpp
@@ -1,5 +1,8 @@
 #include "intel_cracker.h"
+#include <CL/cl.h>
+#include <fstream>
 #include <iostream>
+#include <vector>
 
 namespace darkling {
 
@@ -11,11 +14,77 @@ bool IntelCracker::initialize() {
 }
 
 bool IntelCracker::load_job(const MaskJob &job) {
-    (void)job;
+    job_ = job;
     return true;
 }
 
 bool IntelCracker::run_batch() {
+    cl_uint num=0;
+    if(clGetPlatformIDs(0,nullptr,&num)!=CL_SUCCESS||num==0) return false;
+    std::vector<cl_platform_id> plats(num);
+    clGetPlatformIDs(num, plats.data(), nullptr);
+    cl_device_id dev;
+    clGetDeviceIDs(plats[0], CL_DEVICE_TYPE_DEFAULT,1,&dev,nullptr);
+    cl_int err=0;
+    cl_context ctx=clCreateContext(nullptr,1,&dev,nullptr,nullptr,&err);
+    cl_command_queue q=clCreateCommandQueue(ctx,dev,0,&err);
+
+    std::ifstream file("darkling/intel_backend/opencl_kernel.cl");
+    std::string src((std::istreambuf_iterator<char>(file)),{});
+    const char* sc=src.c_str(); size_t sl=src.size();
+    cl_program prog=clCreateProgramWithSource(ctx,1,&sc,&sl,&err);
+    clBuildProgram(prog,0,nullptr,nullptr,nullptr,nullptr);
+    cl_kernel kr=clCreateKernel(prog,"crack_kernel",&err);
+
+    static uint8_t cs_bytes[MAX_CUSTOM_SETS][MAX_CHARSET_CHARS][MAX_UTF8_BYTES];
+    static uint8_t cs_lens[MAX_CUSTOM_SETS][MAX_CHARSET_CHARS];
+    static int cs_sizes[MAX_CUSTOM_SETS];
+    for(int s=0;s<MAX_CUSTOM_SETS;s++){
+        int len=job_.charset_lengths[s];
+        cs_sizes[s]=len;
+        for(int i=0;i<len;i++){ cs_bytes[s][i][0]=job_.charsets[s][i]; cs_lens[s][i]=1; }
+    }
+
+    cl_mem pos_buf=clCreateBuffer(ctx,CL_MEM_READ_ONLY|CL_MEM_COPY_HOST_PTR,job_.mask_length,job_.mask_template,&err);
+    cl_mem bytes_buf=clCreateBuffer(ctx,CL_MEM_READ_ONLY|CL_MEM_COPY_HOST_PTR,sizeof(cs_bytes),cs_bytes,&err);
+    cl_mem len_buf=clCreateBuffer(ctx,CL_MEM_READ_ONLY|CL_MEM_COPY_HOST_PTR,sizeof(cs_lens),cs_lens,&err);
+    cl_mem size_buf=clCreateBuffer(ctx,CL_MEM_READ_ONLY|CL_MEM_COPY_HOST_PTR,sizeof(cs_sizes),cs_sizes,&err);
+    size_t hash_sz=job_.num_hashes*job_.hash_length;
+    cl_mem hash_buf=clCreateBuffer(ctx,CL_MEM_READ_ONLY|CL_MEM_COPY_HOST_PTR,hash_sz,job_.hashes,&err);
+    cl_mem res_buf=clCreateBuffer(ctx,CL_MEM_WRITE_ONLY,MAX_RESULT_BUFFER*MAX_PWD_BYTES,nullptr,&err);
+    cl_mem cnt_buf=clCreateBuffer(ctx,CL_MEM_READ_WRITE|CL_MEM_COPY_HOST_PTR,sizeof(int),&(int){0},&err);
+
+    int idx=0;
+    clSetKernelArg(kr,idx++,sizeof(cl_ulong),&job_.start_index);
+    cl_ulong total=job_.end_index-job_.start_index; clSetKernelArg(kr,idx++,sizeof(cl_ulong),&total);
+    clSetKernelArg(kr,idx++,sizeof(cl_mem),&pos_buf);
+    clSetKernelArg(kr,idx++,sizeof(cl_mem),&bytes_buf);
+    clSetKernelArg(kr,idx++,sizeof(cl_mem),&len_buf);
+    clSetKernelArg(kr,idx++,sizeof(cl_mem),&size_buf);
+    clSetKernelArg(kr,idx++,sizeof(cl_mem),&hash_buf);
+    clSetKernelArg(kr,idx++,sizeof(int),&job_.num_hashes);
+    clSetKernelArg(kr,idx++,sizeof(int),&job_.hash_length);
+    clSetKernelArg(kr,idx++,sizeof(int),&job_.mask_length);
+    clSetKernelArg(kr,idx++,sizeof(cl_mem),&res_buf);
+    clSetKernelArg(kr,idx++,sizeof(int),&(int){MAX_RESULT_BUFFER});
+    clSetKernelArg(kr,idx++,sizeof(cl_mem),&cnt_buf);
+
+    size_t global=64;
+    clEnqueueNDRangeKernel(q,kr,1,nullptr,&global,nullptr,0,nullptr,nullptr);
+    clFinish(q);
+
+    clReleaseMemObject(pos_buf);
+    clReleaseMemObject(bytes_buf);
+    clReleaseMemObject(len_buf);
+    clReleaseMemObject(size_buf);
+    clReleaseMemObject(hash_buf);
+    clReleaseMemObject(res_buf);
+    clReleaseMemObject(cnt_buf);
+    clReleaseKernel(kr);
+    clReleaseProgram(prog);
+    clReleaseCommandQueue(q);
+    clReleaseContext(ctx);
+
     return true;
 }
 

--- a/darkling/intel_backend/intel_cracker.h
+++ b/darkling/intel_backend/intel_cracker.h
@@ -15,6 +15,9 @@ public:
     bool run_batch() override;
     std::vector<CrackResult> read_results() override;
     GpuStatus get_status() override;
+
+private:
+    MaskJob job_{};
 };
 
 } // namespace darkling

--- a/darkling/intel_backend/opencl_kernel.cl
+++ b/darkling/intel_backend/opencl_kernel.cl
@@ -1,0 +1,99 @@
+/* OpenCL port of darkling_engine.cu */
+#pragma OPENCL EXTENSION cl_khr_byte_addressable_store : enable
+
+#define MAX_MASK_LEN 32
+#define MAX_UTF8_BYTES 4
+#define MAX_CUSTOM_SETS 16
+#define MAX_CHARSET_CHARS 256
+#define MAX_PWD_BYTES (MAX_MASK_LEN * MAX_UTF8_BYTES)
+#define MAX_HASHES 1024
+
+inline uint rotl32(uint x, uint n) { return (x<<n) | (x>>(32-n)); }
+
+void md5(const __private char *msg, int len, __global uchar *out) {
+    const uint init[4] = {0x67452301,0xefcdab89,0x98badcfe,0x10325476};
+    uint a=init[0], b=init[1], c=init[2], d=init[3];
+    uchar buffer[64];
+    for(int i=0;i<64;i++) buffer[i]=0;
+    for(int i=0;i<len;i++) buffer[i]=(uchar)msg[i];
+    buffer[len]=0x80;
+    ulong bits=(ulong)len*8;
+    for(int i=0;i<8;i++) buffer[56+i]=(bits>>(8*i))&0xff;
+    const uint k[64]={
+        0xd76aa478,0xe8c7b756,0x242070db,0xc1bdceee,0xf57c0faf,0x4787c62a,0xa8304613,0xfd469501,
+        0x698098d8,0x8b44f7af,0xffff5bb1,0x895cd7be,0x6b901122,0xfd987193,0xa679438e,0x49b40821,
+        0xf61e2562,0xc040b340,0x265e5a51,0xe9b6c7aa,0xd62f105d,0x02441453,0xd8a1e681,0xe7d3fbc8,
+        0x21e1cde6,0xc33707d6,0xf4d50d87,0x455a14ed,0xa9e3e905,0xfcefa3f8,0x676f02d9,0x8d2a4c8a,
+        0xfffa3942,0x8771f681,0x6d9d6122,0xfde5380c,0xa4beea44,0x4bdecfa9,0xf6bb4b60,0xbebfbc70,
+        0x289b7ec6,0xeaa127fa,0xd4ef3085,0x04881d05,0xd9d4d039,0xe6db99e5,0x1fa27cf8,0xc4ac5665,
+        0xf4292244,0x432aff97,0xab9423a7,0xfc93a039,0x655b59c3,0x8f0ccc92,0xffeff47d,0x85845dd1,
+        0x6fa87e4f,0xfe2ce6e0,0xa3014314,0x4e0811a1,0xf7537e82,0xbd3af235,0x2ad7d2bb,0xeb86d391};
+    const uint r[64]={7,12,17,22,7,12,17,22,7,12,17,22,7,12,17,22,
+        5,9,14,20,5,9,14,20,5,9,14,20,5,9,14,20,
+        4,11,16,23,4,11,16,23,4,11,16,23,4,11,16,23,
+        6,10,15,21,6,10,15,21,6,10,15,21,6,10,15,21};
+    uint w[16];
+    for(int i=0;i<16;i++) w[i]=(uint)buffer[i*4]|((uint)buffer[i*4+1]<<8)|((uint)buffer[i*4+2]<<16)|((uint)buffer[i*4+3]<<24);
+    uint aa=a,bb=b,cc=c,dd=d;
+    for(int i=0;i<64;i++){
+        uint f,g;
+        if(i<16){f=(b&c)|(~b&d);g=i;} else if(i<32){f=(d&b)|(~d&c);g=(5*i+1)&15;} else if(i<48){f=b^c^d;g=(3*i+5)&15;} else {f=c^(b|~d);g=(7*i)&15;}
+        uint temp=d; d=c; c=b; uint t=a+f+k[i]+w[g]; b+=rotl32(t,r[i]); a=temp;
+    }
+    a+=aa; b+=bb; c+=cc; d+=dd;
+    uint out32[4]={a,b,c,d};
+    for(int i=0;i<4;i++){ out[i*4]=(out32[i])&0xff; out[i*4+1]=(out32[i]>>8)&0xff; out[i*4+2]=(out32[i]>>16)&0xff; out[i*4+3]=(out32[i]>>24)&0xff; }
+}
+
+__kernel void crack_kernel(
+    ulong start,
+    ulong total,
+    __global const uchar *pos_charset,
+    __global const uchar *charset_bytes,
+    __global const uchar *charset_len,
+    __global const int *charset_size,
+    __global const uchar *hashes,
+    int num_hashes,
+    int hash_len,
+    int pwd_len,
+    __global char *results,
+    int max_results,
+    __global int *count)
+{
+    ulong idx=start+get_global_id(0);
+    ulong step=get_global_size(0);
+    uchar pwd[MAX_PWD_BYTES];
+    uchar idx_buf[MAX_MASK_LEN];
+    uchar digest[20];
+    ulong end=start+total;
+    while(idx<end){
+        ulong val=idx;
+        for(int pos=pwd_len-1;pos>=0;--pos){
+            int set=pos_charset[pos];
+            int len=charset_size[set];
+            idx_buf[pos]=val%len;
+            val/=len;
+        }
+        int out_len=0;
+        for(int pos=0;pos<pwd_len;++pos){
+            int set=pos_charset[pos];
+            int ci=idx_buf[pos];
+            int clen=charset_len[set*MAX_CHARSET_CHARS+ci];
+            for(int j=0;j<clen;j++) pwd[out_len++]=charset_bytes[(set*MAX_CHARSET_CHARS+ci)*MAX_UTF8_BYTES+j];
+        }
+        md5((const char*)pwd,out_len,digest);
+        for(int h=0;h<num_hashes;++h){
+            int match=1;
+            for(int i=0;i<hash_len;i++){ if(digest[i]!=hashes[h*hash_len+i]){match=0;break;} }
+            if(match){
+                int slot=atomic_inc(count);
+                if(slot<max_results){
+                    int off=slot*MAX_PWD_BYTES;
+                    for(int i=0;i<out_len;i++) results[off+i]=pwd[i];
+                    results[off+out_len]='\0';
+                }
+            }
+        }
+        idx+=step;
+    }
+}

--- a/tests/test_darkling_backends.py
+++ b/tests/test_darkling_backends.py
@@ -1,0 +1,35 @@
+import os
+import sys
+import shutil
+import pytest
+
+ROOT = os.path.dirname(os.path.dirname(__file__))
+sys.path.insert(0, ROOT)
+
+try:
+    import pyopencl as cl
+except Exception:
+    cl = None
+
+OPENCL_KERNEL = os.path.join(ROOT, 'darkling', 'intel_backend', 'opencl_kernel.cl')
+
+@pytest.mark.skipif(cl is None, reason="pyopencl not installed")
+def test_opencl_kernel_compiles():
+    try:
+        plats = cl.get_platforms()
+    except cl.LogicError:
+        pytest.skip('no OpenCL platform')
+    if not plats:
+        pytest.skip('no OpenCL platform')
+    ctx = cl.Context(devices=[plats[0].get_devices()[0]])
+    with open(OPENCL_KERNEL) as f:
+        src = f.read()
+    program = cl.Program(ctx, src).build()
+    assert 'crack_kernel' in program.get_info(cl.program_info.KERNEL_NAMES)
+
+def test_hip_kernel_present():
+    hipcc = shutil.which('hipcc')
+    if hipcc is None:
+        pytest.skip('hipcc not available')
+    path = os.path.join(ROOT, 'darkling', 'hip_backend', 'darkling_engine.hip')
+    assert os.path.exists(path)


### PR DESCRIPTION
## Summary
- port CUDA kernel to HIP and OpenCL
- implement minimal buffer handling in `HipCracker` and `IntelCracker`
- provide a CMake build file for optional HIP/OpenCL backends
- document build instructions
- add tests that check kernel presence/compilation when runtimes exist

## Testing
- `pytest -q tests/test_darkling_backends.py`

------
https://chatgpt.com/codex/tasks/task_e_687d9110ee4c832688c6c3f48f219c46