### PR TITLE
Add pattern mask export utilities

### DIFF
--- a/Server/main.py
+++ b/Server/main.py
@@ -28,6 +28,7 @@ from waifus import assign_waifu
 from auth_utils import verify_signature, verify_signature_with_key
 from pydantic import BaseModel
 from ascii_logo import print_logo
+from pattern_to_mask import get_top_masks
 
 app = FastAPI()
 
@@ -483,6 +484,16 @@ async def list_masks():
         return [f.name for f in MASKS_DIR.iterdir() if f.is_file()]
     except Exception as e:
         log_error("server", "system", "S706", "Failed to list masks", e)
+        return []
+
+
+@app.get("/top_masks")
+async def export_top_masks(limit: int = 10):
+    """Return the top password masks derived from stored patterns."""
+    try:
+        return get_top_masks(limit)
+    except Exception as e:
+        log_error("server", "system", "S736", "Failed to export masks", e)
         return []
 
 

--- a/Server/pattern_to_mask.py
+++ b/Server/pattern_to_mask.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+"""Convert stored password patterns into hashcat-style masks."""
+
+import argparse
+from typing import List
+
+from redis_utils import get_redis
+from pattern_stats import TOKEN_RE
+
+TOKEN_TO_MASK = {
+    "$U": "?u",
+    "$l": "?l",
+    "$d": "?d",
+    "$c": "?s",
+    "$s": "?a",
+    "$e": "?a",
+}
+
+def pattern_to_mask(pattern: str) -> str:
+    """Translate a stored pattern to a hashcat mask string."""
+    tokens = TOKEN_RE.findall(pattern)
+    return "".join(TOKEN_TO_MASK.get(t, "?a") for t in tokens)
+
+
+def get_top_masks(count: int, key: str = "dictionary:patterns", r=None) -> List[str]:
+    """Return ``count`` masks generated from the most common patterns."""
+    if r is None:
+        r = get_redis()
+    raw = r.zrevrange(key, 0, count - 1)
+    masks: List[str] = []
+    for item in raw:
+        pattern = item.decode() if isinstance(item, bytes) else item
+        masks.append(pattern_to_mask(pattern))
+    return masks
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--count", type=int, default=10, help="Number of masks to output")
+    parser.add_argument("--key", default="dictionary:patterns", help="Redis key containing patterns")
+    args = parser.parse_args()
+    for mask in get_top_masks(args.count, args.key):
+        print(mask)

--- a/tests/test_pattern_to_mask.py
+++ b/tests/test_pattern_to_mask.py
@@ -1,0 +1,27 @@
+import os
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(__file__))
+sys.path.insert(0, ROOT)
+sys.path.insert(0, os.path.join(ROOT, "Server"))
+
+import pattern_to_mask
+
+class FakeRedis:
+    def __init__(self):
+        self.data = {}
+
+    def zrevrange(self, key, start, end):
+        ordered = sorted(self.data.items(), key=lambda x: -x[1])
+        return [p for p, _ in ordered[start:end+1]]
+
+def test_pattern_to_mask_simple():
+    assert pattern_to_mask.pattern_to_mask("$U$l$d") == "?u?l?d"
+
+def test_get_top_masks(monkeypatch):
+    fake = FakeRedis()
+    fake.data = {"$U$l$d": 5, "$l$l": 2}
+    monkeypatch.setattr(pattern_to_mask, "get_redis", lambda: fake)
+    masks = pattern_to_mask.get_top_masks(1)
+    assert masks == ["?u?l?d"]
+


### PR DESCRIPTION
## Summary
- output top patterns from `learn_trends.py`
- convert patterns to hashcat masks via `pattern_to_mask.py`
- expose `/top_masks` endpoint for exporting generated masks
- test mask generation logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d96c2cc208326a1aff5a73b5daebc