### PR TITLE
Increase MAX_HASHES upper bound

### DIFF
--- a/darkling/darkling_engine.h
+++ b/darkling/darkling_engine.h
@@ -8,7 +8,7 @@
 #define MAX_CHARSET_CHARS 256
 #define MAX_PWD_BYTES (MAX_MASK_LEN * MAX_UTF8_BYTES)
 #define MAX_CHARSET_SIZE (MAX_CHARSET_CHARS * MAX_UTF8_BYTES)
-#define MAX_HASHES 1024
+#define MAX_HASHES 2048
 
 #ifdef __cplusplus
 extern "C" {

--- a/darkling/gpu_shared_types.h
+++ b/darkling/gpu_shared_types.h
@@ -6,7 +6,7 @@
 // Max limits
 #define MAX_CHARSETS 16
 #define MAX_MASK_LEN 32
-#define MAX_HASHES 4096
+#define MAX_HASHES 2048
 #define MAX_RESULT_BUFFER 512
 
 // Job Configuration (passed to GPU)

--- a/darkling/intel_backend/opencl_kernel.cl
+++ b/darkling/intel_backend/opencl_kernel.cl
@@ -6,7 +6,7 @@
 #define MAX_CUSTOM_SETS 16
 #define MAX_CHARSET_CHARS 256
 #define MAX_PWD_BYTES (MAX_MASK_LEN * MAX_UTF8_BYTES)
-#define MAX_HASHES 1024
+#define MAX_HASHES 2048
 
 inline uint rotl32(uint x, uint n) { return (x<<n) | (x>>(32-n)); }
 


### PR DESCRIPTION
## Summary
- expand supported hash count to 2048
- keep constant memory usage under 64KiB

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d9a85b39083268b4301878778a68e