### PR TITLE
Add language option for pattern stats

### DIFF
--- a/Server/learn_trends.py
+++ b/Server/learn_trends.py
@@ -9,8 +9,11 @@ from redis_utils import get_redis
 from pattern_utils import word_to_pattern, is_valid_word
 
 
-def process_wordlists(directory: Path) -> None:
-    """Parse all files in ``directory`` and increment pattern counts."""
+def process_wordlists(directory: Path, lang: str = "english") -> None:
+    """Parse all files in ``directory`` and increment pattern counts.
+
+    The pattern counts are stored in the ``dictionary:patterns:<lang>`` key.
+    """
     r = get_redis()
     for path in directory.iterdir():
         if not path.is_file():
@@ -21,14 +24,14 @@ def process_wordlists(directory: Path) -> None:
                 if not is_valid_word(word):
                     continue
                 pattern = word_to_pattern(word)
-                r.zincrby("dictionary:patterns", 1, pattern)
+                r.zincrby(f"dictionary:patterns:{lang}", 1, pattern)
 
 
-def top_patterns(count: int, r=None) -> list[tuple[str, int]]:
-    """Return ``count`` most common patterns and their counts."""
+def top_patterns(count: int, lang: str = "english", r=None) -> list[tuple[str, int]]:
+    """Return ``count`` most common patterns for *lang* and their counts."""
     if r is None:
         r = get_redis()
-    results = r.zrevrange("dictionary:patterns", 0, count - 1, withscores=True)
+    results = r.zrevrange(f"dictionary:patterns:{lang}", 0, count - 1, withscores=True)
     patterns: list[tuple[str, int]] = []
     for pat, score in results:
         if isinstance(pat, bytes):
@@ -45,8 +48,11 @@ if __name__ == "__main__":
     parser.add_argument(
         "--top", type=int, default=0, help="Show N most common patterns after processing",
     )
+    parser.add_argument(
+        "--lang", default="english", help="Language identifier for pattern statistics",
+    )
     args = parser.parse_args()
-    process_wordlists(args.directory)
+    process_wordlists(args.directory, args.lang)
     if args.top:
-        for pattern, count in top_patterns(args.top):
+        for pattern, count in top_patterns(args.top, args.lang):
             print(f"{pattern} {count}")

--- a/Server/pattern_to_mask.py
+++ b/Server/pattern_to_mask.py
@@ -22,10 +22,11 @@ def pattern_to_mask(pattern: str) -> str:
     return "".join(TOKEN_TO_MASK.get(t, "?a") for t in tokens)
 
 
-def get_top_masks(count: int, key: str = "dictionary:patterns", r=None) -> List[str]:
+def get_top_masks(count: int, lang: str = "english", r=None) -> List[str]:
     """Return ``count`` masks generated from the most common patterns."""
     if r is None:
         r = get_redis()
+    key = f"dictionary:patterns:{lang}"
     raw = r.zrevrange(key, 0, count - 1)
     masks: List[str] = []
     for item in raw:
@@ -37,7 +38,7 @@ def get_top_masks(count: int, key: str = "dictionary:patterns", r=None) -> List[
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--count", type=int, default=10, help="Number of masks to output")
-    parser.add_argument("--key", default="dictionary:patterns", help="Redis key containing patterns")
+    parser.add_argument("--lang", default="english", help="Language identifier for pattern statistics")
     args = parser.parse_args()
-    for mask in get_top_masks(args.count, args.key):
+    for mask in get_top_masks(args.count, args.lang):
         print(mask)

--- a/darkling/statistics.py
+++ b/darkling/statistics.py
@@ -47,11 +47,11 @@ def build_markov(records: Iterable[tuple[str, int]]) -> dict:
     return {"start": dict(start), "trans": out_trans}
 
 
-def load_markov(r=None) -> dict:
-    """Load pattern statistics from Redis and build Markov tables."""
+def load_markov(r=None, lang: str = "english") -> dict:
+    """Load pattern statistics for *lang* from Redis and build Markov tables."""
     if r is None:
         r = get_redis()
-    pairs = r.zrange("dictionary:patterns", 0, -1, withscores=True)
+    pairs = r.zrange(f"dictionary:patterns:{lang}", 0, -1, withscores=True)
     return build_markov((p, int(s)) for p, s in pairs)
 
 

--- a/tests/test_language_patterns.py
+++ b/tests/test_language_patterns.py
@@ -1,0 +1,74 @@
+import os
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(__file__))
+sys.path.insert(0, ROOT)
+sys.path.insert(0, os.path.join(ROOT, "Server"))
+
+from Server import learn_trends
+from darkling import statistics
+from Server import pattern_to_mask
+
+
+class FakeRedis:
+    def __init__(self):
+        self.store = {}
+
+    # sorted set helpers
+    def zincrby(self, key, amt, member):
+        self.store.setdefault(key, {})
+        self.store[key][member] = self.store[key].get(member, 0) + amt
+
+    def zrevrange(self, key, start, end, withscores=False):
+        items = self.store.get(key, {})
+        ordered = sorted(items.items(), key=lambda x: -x[1])
+        if end == -1:
+            result = ordered[start:]
+        else:
+            result = ordered[start:end + 1]
+        if withscores:
+            return [(p, v) for p, v in result]
+        return [p for p, _ in result]
+
+    def zrange(self, key, start, end, withscores=False):
+        items = self.store.get(key, {})
+        ordered = sorted(items.items(), key=lambda x: x[1])
+        if end == -1:
+            result = ordered[start:]
+        else:
+            result = ordered[start:end + 1]
+        if withscores:
+            return [(p, v) for p, v in result]
+        return [p for p, _ in result]
+
+
+def test_lang_specific_storage_and_top(monkeypatch, tmp_path):
+    fake = FakeRedis()
+    monkeypatch.setattr(learn_trends, "get_redis", lambda: fake)
+    wl = tmp_path / "wl.txt"
+    wl.write_text("Password1\nhello\n")
+
+    learn_trends.process_wordlists(tmp_path, lang="testlang")
+
+    assert f"dictionary:patterns:testlang" in fake.store
+
+    res = learn_trends.top_patterns(1, lang="testlang", r=fake)
+    assert res
+
+
+def test_load_markov_lang(monkeypatch):
+    fake = FakeRedis()
+    fake.zincrby("dictionary:patterns:english", 3, "$U$l")
+    fake.zincrby("dictionary:patterns:english", 1, "$l$l")
+
+    markov = statistics.load_markov(r=fake, lang="english")
+    assert markov["start"].get("$U") == 3
+
+
+def test_get_top_masks_lang(monkeypatch):
+    fake = FakeRedis()
+    fake.zincrby("dictionary:patterns:french", 2, "$l$d")
+    monkeypatch.setattr(pattern_to_mask, "get_redis", lambda: fake)
+    masks = pattern_to_mask.get_top_masks(1, lang="french")
+    assert masks == ["?l?d"]
+

--- a/tests/test_pattern_to_mask.py
+++ b/tests/test_pattern_to_mask.py
@@ -12,7 +12,8 @@ class FakeRedis:
         self.data = {}
 
     def zrevrange(self, key, start, end):
-        ordered = sorted(self.data.items(), key=lambda x: -x[1])
+        items = self.data.get(key, {})
+        ordered = sorted(items.items(), key=lambda x: -x[1])
         return [p for p, _ in ordered[start:end+1]]
 
 def test_pattern_to_mask_simple():
@@ -20,7 +21,7 @@ def test_pattern_to_mask_simple():
 
 def test_get_top_masks(monkeypatch):
     fake = FakeRedis()
-    fake.data = {"$U$l$d": 5, "$l$l": 2}
+    fake.data = {"dictionary:patterns:english": {"$U$l$d": 5, "$l$l": 2}}
     monkeypatch.setattr(pattern_to_mask, "get_redis", lambda: fake)
     masks = pattern_to_mask.get_top_masks(1)
     assert masks == ["?u?l?d"]


### PR DESCRIPTION
## Summary
- extend `learn_trends.py` with `--lang` argument and store per-language pattern counts
- load per-language statistics in `darkling.statistics.load_markov`
- allow pattern to mask conversion to pick language
- adjust related tests and add language specific test coverage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687dafa13e4c8326801590101ee15ff8