### PR TITLE
Add root portal route with auth checks

### DIFF
--- a/Server/main.py
+++ b/Server/main.py
@@ -184,7 +184,8 @@ class PortalAuthMiddleware:
         if scope.get("type") == "http" and self.key:
             path = scope.get("path", "")
             if (
-                path.startswith("/portal")
+                path == "/"
+                or path.startswith("/portal")
                 or path.startswith("/glyph")
                 or path.startswith("/admin")
             ):
@@ -1120,6 +1121,7 @@ async def admin_page():
         return HTMLResponse("<h1>Admin page not available</h1>", status_code=500)
 
 
+@app.get("/", response_class=HTMLResponse)
 @app.get("/portal", response_class=HTMLResponse)
 async def portal_page():
     """Serve the combined portal interface."""

--- a/tests/test_auth_middleware.py
+++ b/tests/test_auth_middleware.py
@@ -170,6 +170,22 @@ def test_portal_auth_denies_without_key(monkeypatch):
     assert events and events[0]["status"] == 401
 
 
+def test_root_auth_denies_without_key(monkeypatch):
+    events = []
+
+    async def send(evt):
+        events.append(evt)
+
+    app = FakeApp()
+    mw = main.PortalAuthMiddleware(app, key="secret")
+    scope = {"type": "http", "path": "/", "headers": []}
+
+    asyncio.run(mw(scope, lambda: None, send))
+
+    assert not app.called
+    assert events and events[0]["status"] == 401
+
+
 def test_portal_auth_allows_with_key(monkeypatch):
     events = []
 
@@ -179,6 +195,22 @@ def test_portal_auth_allows_with_key(monkeypatch):
     app = FakeApp()
     mw = main.PortalAuthMiddleware(app, key="secret")
     scope = {"type": "http", "path": "/portal", "headers": [(b"x-api-key", b"secret")]} 
+
+    asyncio.run(mw(scope, lambda: None, send))
+
+    assert app.called
+    assert events and events[0].get("done") is True
+
+
+def test_root_auth_allows_with_key(monkeypatch):
+    events = []
+
+    async def send(evt):
+        events.append(evt)
+
+    app = FakeApp()
+    mw = main.PortalAuthMiddleware(app, key="secret")
+    scope = {"type": "http", "path": "/", "headers": [(b"x-api-key", b"secret")]}
 
     asyncio.run(mw(scope, lambda: None, send))
 


### PR DESCRIPTION
## Summary
- expose the portal HTML at `/` in addition to `/portal`
- protect the new root path using `PortalAuthMiddleware`
- test middleware behaviour for the new route

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e478761c88326be519d50423a7c5b