### PR TITLE
Generate passkey during server setup

### DIFF
--- a/Server/README.md
+++ b/Server/README.md
@@ -69,6 +69,7 @@ This will:
 - Configure Redis and logging
 - Install a systemd service
 - Optionally enable a UDP broadcast so workers can auto-discover the server
+- Generate a random portal passkey and show it at the end
 
 3. Start the server (if not done via systemd):
 
@@ -227,14 +228,14 @@ To restrict access to the web dashboard set `"portal_key"` in
 ### Portal passkey
 
 Dashboard logins also require a `"portal_passkey"` in `~/.hashmancer/server_config.json`.
-Generate one with the helper function in `setup.py`:
+The interactive setup script now creates one automatically and prints it when
+setup finishes. If you ever need to generate a new key manually run:
 
 ```bash
 python3 -c 'from Server.setup import generate_passkey; generate_passkey()'
 ```
 
-This writes a random key to the config file. To obtain a session token send the
-passkey to `/login`:
+After setup, send the passkey to `/login` to obtain a session token:
 
 ```bash
 curl -X POST -H 'Content-Type: application/json' \

--- a/Server/setup.py
+++ b/Server/setup.py
@@ -153,6 +153,9 @@ def configure():
         "broadcast_port": int(broadcast_port),
     }
 
+    passkey = generate_passkey()
+    config["portal_passkey"] = passkey
+
     with open(CONFIG_FILE, "w") as f:
         json.dump(config, f, indent=2)
 
@@ -164,6 +167,8 @@ def configure():
     print("\n🎉 Setup complete.")
     print(f"🔑 Config: {CONFIG_FILE}")
     print(f"🔐 API key: {ENV_FILE}")
+    print(f"🔑 Portal passkey: {passkey}")
+    print("   Use this key when logging in to the dashboard for the first time.")
     print("🧠 Server URL:", server_url)
     print("🟢 Service: hashmancer-server (enabled & running)")
 


### PR DESCRIPTION
## Summary
- call `generate_passkey()` from `Server.setup.configure`
- show the passkey at the end of setup so users can log in
- document automatic passkey generation in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e557c6da883268439c9edcb07ba7e