### PR TITLE
Add host metrics to server_status

### DIFF
--- a/Server/glyph.html
+++ b/Server/glyph.html
@@ -51,6 +51,9 @@ canvas {
 <div class="section">Queue Length: <span id="queue">0</span></div>
 <div class="section">Found Results: <span id="results">0</span></div>
 <div class="section">GPU Temps: <span id="gpu">N/A</span></div>
+<div class="section">CPU Usage: <span id="cpu">N/A</span></div>
+<div class="section">Memory Utilization: <span id="memory">N/A</span></div>
+<div class="section">Disk Usage: <span id="disk">N/A</span></div>
 <div class="section">Recent Cracks:
   <ul id="found-list"></ul>
 </div>
@@ -78,6 +81,9 @@ async function updateMetrics() {
     document.getElementById('queue').textContent = data.queue_length;
     document.getElementById('results').textContent = data.found_results;
     document.getElementById('gpu').textContent = (data.gpu_temps || []).join(', ');
+    document.getElementById('cpu').textContent = data.cpu_usage + '%';
+    document.getElementById('memory').textContent = data.memory_utilization + '%';
+    document.getElementById('disk').textContent = data.disk_space + '%';
     document.getElementById('updated').textContent = 'Updated: ' + new Date().toLocaleTimeString();
 }
 

--- a/Server/main.py
+++ b/Server/main.py
@@ -33,6 +33,7 @@ from auth_utils import verify_signature, verify_signature_with_key
 from pydantic import BaseModel
 from ascii_logo import print_logo
 from pattern_to_mask import get_top_masks
+import psutil
 
 app = FastAPI()
 
@@ -607,7 +608,22 @@ async def server_status():
             "low_bw_engine": LOW_BW_ENGINE,
             "probabilistic_order": PROBABILISTIC_ORDER,
             "markov_lang": MARKOV_LANG,
+            "cpu_usage": None,
+            "memory_utilization": None,
+            "disk_space": None,
         }
+        try:
+            status["cpu_usage"] = psutil.cpu_percent(interval=None)
+        except Exception:
+            pass
+        try:
+            status["memory_utilization"] = psutil.virtual_memory().percent
+        except Exception:
+            pass
+        try:
+            status["disk_space"] = psutil.disk_usage("/").percent
+        except Exception:
+            pass
         return status
     except redis.exceptions.RedisError as e:
         log_error("server", "system", "SRED", "Redis unavailable", e)

--- a/Server/requirements.txt
+++ b/Server/requirements.txt
@@ -5,3 +5,4 @@ requests
 pydantic
 cryptography
 python-multipart
+psutil

--- a/tests/test_server_status.py
+++ b/tests/test_server_status.py
@@ -1,0 +1,90 @@
+import asyncio
+import sys
+import os
+import types
+
+# Stub FastAPI and Pydantic similar to other server tests
+fastapi_stub = types.ModuleType("fastapi")
+class FakeApp:
+    def add_middleware(self, *a, **kw):
+        pass
+    def on_event(self, *a, **kw):
+        return lambda f: f
+    def post(self, *a, **kw):
+        return lambda f: f
+    def get(self, *a, **kw):
+        return lambda f: f
+    def delete(self, *a, **kw):
+        return lambda f: f
+    def websocket(self, *a, **kw):
+        return lambda f: f
+fastapi_stub.FastAPI = lambda: FakeApp()
+fastapi_stub.UploadFile = object
+fastapi_stub.File = lambda *a, **kw: None
+fastapi_stub.WebSocket = object
+fastapi_stub.WebSocketDisconnect = type("WebSocketDisconnect", (), {})
+class HTTPException(Exception):
+    pass
+fastapi_stub.HTTPException = HTTPException
+sys.modules.setdefault("fastapi", fastapi_stub)
+
+cors_stub = types.ModuleType("fastapi.middleware.cors")
+cors_stub.CORSMiddleware = object
+sys.modules.setdefault("fastapi.middleware.cors", cors_stub)
+
+resp_stub = types.ModuleType("fastapi.responses")
+resp_stub.HTMLResponse = object
+resp_stub.FileResponse = object
+sys.modules.setdefault("fastapi.responses", resp_stub)
+
+pydantic_stub = types.ModuleType("pydantic")
+class BaseModel:
+    pass
+pydantic_stub.BaseModel = BaseModel
+sys.modules.setdefault("pydantic", pydantic_stub)
+
+# Stub cryptography pieces used by auth_utils
+crypto_stub = types.ModuleType("cryptography")
+exceptions_stub = types.ModuleType("cryptography.exceptions")
+class InvalidSignature(Exception):
+    pass
+exceptions_stub.InvalidSignature = InvalidSignature
+primitives_stub = types.ModuleType("cryptography.hazmat.primitives")
+asym_stub = types.ModuleType("cryptography.hazmat.primitives.asymmetric")
+asym_stub.padding = object()
+primitives_stub.asymmetric = asym_stub
+primitives_stub.hashes = types.SimpleNamespace(SHA256=lambda: None)
+primitives_stub.serialization = types.SimpleNamespace(load_pem_public_key=lambda x: None)
+crypto_stub.hazmat = types.SimpleNamespace(primitives=primitives_stub)
+crypto_stub.exceptions = exceptions_stub
+sys.modules.setdefault("cryptography", crypto_stub)
+sys.modules.setdefault("cryptography.exceptions", exceptions_stub)
+sys.modules.setdefault("cryptography.hazmat.primitives", primitives_stub)
+sys.modules.setdefault("cryptography.hazmat.primitives.asymmetric", asym_stub)
+
+# Stub psutil for system metrics
+psutil_stub = types.ModuleType("psutil")
+psutil_stub.cpu_percent = lambda interval=None: 10.0
+psutil_stub.virtual_memory = lambda: types.SimpleNamespace(percent=20.0)
+psutil_stub.disk_usage = lambda path: types.SimpleNamespace(percent=30.0)
+sys.modules.setdefault("psutil", psutil_stub)
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), 'Server'))
+
+import main
+
+class DummyRedis:
+    def scard(self, key):
+        return 0
+    def llen(self, key):
+        return 0
+
+
+def test_server_status_reports_system_metrics(monkeypatch):
+    fake = DummyRedis()
+    monkeypatch.setattr(main, 'r', fake)
+    status = asyncio.run(main.server_status())
+    assert 'cpu_usage' in status
+    assert 'memory_utilization' in status
+    assert 'disk_space' in status


### PR DESCRIPTION
## Summary
- extend `/server_status` with CPU, memory and disk metrics using psutil
- surface those values on the glyph dashboard
- install psutil
- add unit test ensuring new keys exist in `/server_status`

## Testing
- `pip install -q -r Server/requirements.txt -r Server/requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e5c29b20c8326b72d7278924af0c7