### PR TITLE
Add button to open Glyph dashboard

### DIFF
--- a/Server/portal.html
+++ b/Server/portal.html
@@ -50,6 +50,7 @@ body::before {
 </head>
 <body>
 <h1>Hashmancer Portal</h1>
+<button onclick="location.href='/glyph'">Open Glyph</button>
 <div id="login-overlay">
   <h2>Portal Login</h2>
   <input type="password" id="passkey" placeholder="passkey">


### PR DESCRIPTION
## Summary
- add 'Open Glyph' button after the main header in the portal

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e6d688f9483269644c8b7a4c68bad