### PR TITLE
Expand server_status metrics

### DIFF
--- a/tests/test_server_markov.py
+++ b/tests/test_server_markov.py
@@ -118,6 +118,8 @@ def test_server_status_includes_settings(monkeypatch):
     monkeypatch.setattr(main, 'r', fake)
     monkeypatch.setattr(main, 'PROBABILISTIC_ORDER', True)
     monkeypatch.setattr(main, 'MARKOV_LANG', 'spanish')
+    monkeypatch.setattr(main.orchestrator_agent, 'compute_backlog_target', lambda: 5)
+    monkeypatch.setattr(main.orchestrator_agent, 'pending_count', lambda: 2)
     status = asyncio.run(main.server_status())
     assert status['probabilistic_order'] is True
     assert status['markov_lang'] == 'spanish'


### PR DESCRIPTION
## Summary
- extend `server_status` with additional system metrics
- report backlog target and job counts
- cover new keys in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e731101c083268febbfc19857b436