### PR TITLE
Add login page

### DIFF
--- a/Server/README.md
+++ b/Server/README.md
@@ -244,6 +244,10 @@ curl -X POST -H 'Content-Type: application/json' \
 
 Use the returned `cookie` value as the `session` cookie for subsequent requests.
 
+You can also login through the built-in HTML form by visiting `/login_page` in a
+browser. Enter the passkey and you will be redirected to the portal once the
+`session` cookie is set.
+
 ## 🌐 Reverse Proxy Setup
 
 When exposing Hashmancer to the internet it's best to place a TLS-enabled

--- a/Server/login.html
+++ b/Server/login.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Portal Login</title>
+<link href="https://fonts.googleapis.com/css2?family=UnifrakturCook&display=swap" rel="stylesheet">
+<style>
+body { font-family: Arial, sans-serif; margin:10px; background:#000; color:#0f0; }
+h1 { color:#0f0; text-align:center; font-family:'UnifrakturCook', cursive; }
+input { background:#111; color:#0f0; border:1px solid #0f0; margin-top:4px; }
+button { margin-top:4px; }
+</style>
+</head>
+<body>
+<h1>Portal Login</h1>
+<input type="password" id="passkey" placeholder="passkey">
+<button onclick="submitPasskey()">Login</button>
+<div id="login-error" style="color:red;margin-top:4px;"></div>
+<script>
+async function submitPasskey(){
+  const key=document.getElementById('passkey').value.trim();
+  if(!key) return;
+  const res=await fetch('/login',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({passkey:key})});
+  if(res.ok){
+    const data=await res.json();
+    document.cookie=`session=${data.cookie}; path=/`;
+    location.href='/portal';
+  }else{
+    document.getElementById('login-error').textContent='Invalid passkey';
+  }
+}
+</script>
+</body>
+</html>

--- a/Server/main.py
+++ b/Server/main.py
@@ -1165,6 +1165,17 @@ async def admin_page():
         return HTMLResponse("<h1>Admin page not available</h1>", status_code=500)
 
 
+@app.get("/login_page", response_class=HTMLResponse)
+async def login_page():
+    """Serve a simple login form for the portal."""
+    try:
+        html_path = Path(__file__).parent / "login.html"
+        return html_path.read_text()
+    except Exception as e:
+        log_error("server", "system", "S729", "Failed to load login page", e)
+        return HTMLResponse("<h1>Login page not available</h1>", status_code=500)
+
+
 @app.get("/", response_class=HTMLResponse)
 @app.get("/portal", response_class=HTMLResponse)
 async def portal_page():


### PR DESCRIPTION
## Summary
- add simple login.html with JS that posts passkey
- serve the login page from `/login_page`
- document how to login via the new page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e77716ec48326abcaab831132f352