### PR TITLE
Add LLM configuration options

### DIFF
--- a/Server/README.md
+++ b/Server/README.md
@@ -197,6 +197,16 @@ An optional `LLMOrchestrator` component can load a local language model via
 `transformers` to suggest batch sizes and choose between the high and low
 bandwidth queues. Set `LLM_MODEL_PATH` in the environment to enable it.
 
+To enable it via configuration instead, add these fields to
+`~/.hashmancer/server_config.json`:
+
+```json
+{
+  "llm_enabled": true,
+  "llm_model_path": "/opt/models/distilgpt2"
+}
+```
+
 ---
 
 ## 🚀 Hashmancer Agent


### PR DESCRIPTION
## Summary
- read `llm_enabled` and `llm_model_path` from server_config.json
- expose values in environment before importing the orchestrator
- update `save_config()` so env vars stay in sync
- document LLM options in Server README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ef7d1f8248326a9f33ddf421ccaae