### PR TITLE
Add LLM settings to server config

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,16 @@ also supply `--server-ip` to skip auto-discovery.
 Both the server and worker load their private signing keys once at module import
 time.  The `cryptography` library returns immutable key objects, so concurrent
 threads can safely call the signing helpers without additional locking.
+
+## Example configuration
+
+Settings for the server are loaded from `~/.hashmancer/server_config.json`.
+To enable the optional language model orchestrator and provide the model path
+add these fields:
+
+```json
+{
+  "llm_enabled": true,
+  "llm_model_path": "/opt/models/distilgpt2"
+}
+```

--- a/Server/main.py
+++ b/Server/main.py
@@ -86,6 +86,8 @@ MARKOV_LANG = CONFIG.get("markov_lang", "english")
 # local language model settings
 LLM_ENABLED = bool(CONFIG.get("llm_enabled", False))
 LLM_MODEL_PATH = CONFIG.get("llm_model_path", "")
+
+# propagate the model path for orchestrator_agent if enabled
 if LLM_ENABLED and LLM_MODEL_PATH:
     os.environ["LLM_MODEL_PATH"] = LLM_MODEL_PATH
 else:
@@ -97,10 +99,15 @@ import orchestrator_agent
 def save_config():
     """Persist the CONFIG dictionary to disk."""
     try:
+        # ensure current LLM settings are written to disk
+        CONFIG["llm_enabled"] = bool(LLM_ENABLED)
+        CONFIG["llm_model_path"] = LLM_MODEL_PATH
+
         with open(CONFIG_FILE, "w") as f:
             json.dump(CONFIG, f, indent=2)
-        if CONFIG.get("llm_enabled") and CONFIG.get("llm_model_path"):
-            os.environ["LLM_MODEL_PATH"] = CONFIG["llm_model_path"]
+
+        if LLM_ENABLED and LLM_MODEL_PATH:
+            os.environ["LLM_MODEL_PATH"] = LLM_MODEL_PATH
         else:
             os.environ.pop("LLM_MODEL_PATH", None)
     except Exception as e:


### PR DESCRIPTION
## Summary
- handle `llm_enabled` and `llm_model_path` via server config
- save LLM values when persisting configuration
- document LLM config fields in README

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f781e362c8326be4f6f25dfe8667d