### PR TITLE
Add LLM training defaults to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,13 @@ threads can safely call the signing helpers without additional locking.
 
 Settings for the server are loaded from `~/.hashmancer/server_config.json`.
 To enable the optional language model orchestrator and provide the model path
-add these fields:
+add these fields along with default training parameters:
 
 ```json
 {
   "llm_enabled": true,
-  "llm_model_path": "/opt/models/distilgpt2"
+  "llm_model_path": "/opt/models/distilgpt2",
+  "llm_train_epochs": 1,
+  "llm_train_learning_rate": 0.0001
 }
 ```

--- a/Server/README.md
+++ b/Server/README.md
@@ -203,7 +203,9 @@ To enable it via configuration instead, add these fields to
 ```json
 {
   "llm_enabled": true,
-  "llm_model_path": "/opt/models/distilgpt2"
+  "llm_model_path": "/opt/models/distilgpt2",
+  "llm_train_epochs": 1,
+  "llm_train_learning_rate": 0.0001
 }
 ```
 

--- a/Server/main.py
+++ b/Server/main.py
@@ -90,6 +90,8 @@ MARKOV_LANG = CONFIG.get("markov_lang", "english")
 # local language model settings
 LLM_ENABLED = bool(CONFIG.get("llm_enabled", False))
 LLM_MODEL_PATH = CONFIG.get("llm_model_path", "")
+LLM_TRAIN_EPOCHS = int(CONFIG.get("llm_train_epochs", 1))
+LLM_TRAIN_LEARNING_RATE = float(CONFIG.get("llm_train_learning_rate", 0.0001))
 
 # propagate the model path for orchestrator_agent if enabled
 if LLM_ENABLED and LLM_MODEL_PATH:
@@ -106,6 +108,8 @@ def save_config():
         # ensure current LLM settings are written to disk
         CONFIG["llm_enabled"] = bool(LLM_ENABLED)
         CONFIG["llm_model_path"] = LLM_MODEL_PATH
+        CONFIG["llm_train_epochs"] = int(LLM_TRAIN_EPOCHS)
+        CONFIG["llm_train_learning_rate"] = float(LLM_TRAIN_LEARNING_RATE)
 
         with open(CONFIG_FILE, "w") as f:
             json.dump(CONFIG, f, indent=2)
@@ -681,6 +685,8 @@ async def server_status():
             "low_bw_engine": LOW_BW_ENGINE,
             "probabilistic_order": PROBABILISTIC_ORDER,
             "markov_lang": MARKOV_LANG,
+            "llm_train_epochs": LLM_TRAIN_EPOCHS,
+            "llm_train_learning_rate": LLM_TRAIN_LEARNING_RATE,
             "cpu_usage": None,
             "memory_utilization": None,
             "disk_space": None,

--- a/Server/portal.html
+++ b/Server/portal.html
@@ -190,6 +190,12 @@ function applyMetrics(data){
   document.getElementById('current-markov-lang').textContent = data.markov_lang || '';
   document.getElementById('prob-order').checked = !!data.probabilistic_order;
   document.getElementById('markov-language').value = data.markov_lang || 'english';
+  if(data.llm_train_epochs!==undefined){
+    document.getElementById('llm-epochs').value = data.llm_train_epochs;
+  }
+  if(data.llm_train_learning_rate!==undefined){
+    document.getElementById('llm-lr').value = data.llm_train_learning_rate;
+  }
 }
 async function updateMetrics(){
   const res = await fetch('/server_status');

--- a/tests/test_server_markov.py
+++ b/tests/test_server_markov.py
@@ -118,8 +118,12 @@ def test_server_status_includes_settings(monkeypatch):
     monkeypatch.setattr(main, 'r', fake)
     monkeypatch.setattr(main, 'PROBABILISTIC_ORDER', True)
     monkeypatch.setattr(main, 'MARKOV_LANG', 'spanish')
+    monkeypatch.setattr(main, 'LLM_TRAIN_EPOCHS', 2)
+    monkeypatch.setattr(main, 'LLM_TRAIN_LEARNING_RATE', 0.002)
     monkeypatch.setattr(main.orchestrator_agent, 'compute_backlog_target', lambda: 5)
     monkeypatch.setattr(main.orchestrator_agent, 'pending_count', lambda: 2)
     status = asyncio.run(main.server_status())
     assert status['probabilistic_order'] is True
     assert status['markov_lang'] == 'spanish'
+    assert status['llm_train_epochs'] == 2
+    assert status['llm_train_learning_rate'] == 0.002

--- a/tests/test_server_status.py
+++ b/tests/test_server_status.py
@@ -96,3 +96,15 @@ def test_server_status_reports_system_metrics(monkeypatch):
     assert 'backlog_target' in status
     assert 'pending_jobs' in status
     assert 'queued_batches' in status
+
+
+def test_server_status_reports_llm_defaults(monkeypatch):
+    fake = DummyRedis()
+    monkeypatch.setattr(main, 'r', fake)
+    monkeypatch.setattr(main, 'LLM_TRAIN_EPOCHS', 4)
+    monkeypatch.setattr(main, 'LLM_TRAIN_LEARNING_RATE', 0.003)
+    monkeypatch.setattr(main.orchestrator_agent, 'compute_backlog_target', lambda: 0)
+    monkeypatch.setattr(main.orchestrator_agent, 'pending_count', lambda: 0)
+    status = asyncio.run(main.server_status())
+    assert status['llm_train_epochs'] == 4
+    assert status['llm_train_learning_rate'] == 0.003


### PR DESCRIPTION
## Summary
- store `llm_train_epochs` and `llm_train_learning_rate` in `save_config`
- expose those defaults through `/server_status`
- populate the portal training form with the saved defaults
- document example configuration values
- cover the new metrics in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68801fe274248326900831ca409e9482