### PR TITLE
Track keyspace progress

### DIFF
--- a/Server/main.py
+++ b/Server/main.py
@@ -566,6 +566,14 @@ async def submit_founds(payload: dict):
         if msg_id:
             r.xack(stream, group, msg_id)
 
+        try:
+            start = int(info.get("start", 0))
+            end = int(info.get("end", 0))
+            if start or end:
+                redis_manager.complete_range(payload["batch_id"], start, end)
+        except Exception:
+            pass
+
         r.hset(f"worker:{payload['worker_id']}", "status", "idle")
         return {"status": "ok", "received": len(payload["founds"])}
     except redis.exceptions.RedisError as e:
@@ -595,6 +603,14 @@ async def submit_no_founds(payload: dict):
         group = HTTP_GROUP if stream == JOB_STREAM else LOW_BW_GROUP
         if msg_id:
             r.xack(stream, group, msg_id)
+
+        try:
+            start = int(info.get("start", 0))
+            end = int(info.get("end", 0))
+            if start or end:
+                redis_manager.complete_range(payload["batch_id"], start, end)
+        except Exception:
+            pass
 
         r.hset(f"worker:{payload['worker_id']}", "status", "idle")
         return {"status": "ok"}

--- a/Server/redis_manager.py
+++ b/Server/redis_manager.py
@@ -3,6 +3,7 @@ from redis_utils import get_redis
 import json
 import uuid
 import time
+import orchestrator_agent
 
 r = get_redis()
 
@@ -17,6 +18,13 @@ def store_batch(
 ):
     batch_id = str(uuid.uuid4())
     try:
+        keyspace = 0
+        if mask:
+            try:
+                cs_map = orchestrator_agent.build_mask_charsets()
+                keyspace = orchestrator_agent.estimate_keyspace(mask, cs_map)
+            except Exception:
+                keyspace = 0
         r.hset(
             f"batch:{batch_id}",
             mapping={
@@ -27,10 +35,14 @@ def store_batch(
                 "target": json.dumps(target),
                 "status": "queued",
                 "hash_mode": str(hash_mode),
+                "keyspace": keyspace,
             },
         )
         r.expire(f"batch:{batch_id}", ttl)
         r.lpush("batch:queue", batch_id)
+        for h in hashes:
+            r.sadd(f"hash_batches:{h}", batch_id)
+            r.expire(f"hash_batches:{h}", ttl)
     except redis.exceptions.RedisError as e:
         print(f"Redis unavailable: {e}")
         return None
@@ -55,3 +67,20 @@ def requeue_batch(batch_id):
         r.lpush("batch:queue", batch_id)
     except redis.exceptions.RedisError as e:
         print(f"Redis unavailable: {e}")
+
+
+def queue_range(batch_id: str, start: int, end: int) -> None:
+    """Record a keyspace range as queued for the batch."""
+    try:
+        r.rpush(f"keyspace:queued:{batch_id}", f"{start}:{end}")
+    except redis.exceptions.RedisError:
+        pass
+
+
+def complete_range(batch_id: str, start: int, end: int) -> None:
+    """Mark a keyspace range as completed for the batch."""
+    try:
+        r.rpush(f"keyspace:done:{batch_id}", f"{start}:{end}")
+        r.lrem(f"keyspace:queued:{batch_id}", 0, f"{start}:{end}")
+    except redis.exceptions.RedisError:
+        pass

--- a/tests/test_redis_manager.py
+++ b/tests/test_redis_manager.py
@@ -15,6 +15,12 @@ class FakeRedis:
         self.store = {}
         self.queue = []
 
+    def sadd(self, key, value):
+        self.store.setdefault(key, set()).add(value)
+
+    def smembers(self, key):
+        return self.store.get(key, set())
+
     def hset(self, key, mapping=None, **kwargs):
         self.store[key] = dict(mapping or {})
 
@@ -23,6 +29,14 @@ class FakeRedis:
 
     def lpush(self, name, value):
         self.queue.insert(0, value)
+
+    def rpush(self, name, value):
+        self.store.setdefault(name, []).append(value)
+
+    def lrem(self, name, count, value):
+        lst = self.store.get(name, [])
+        while value in lst:
+            lst.remove(value)
 
     def rpop(self, name):
         return self.queue.pop() if self.queue else None
@@ -35,6 +49,8 @@ def test_store_and_get_batch(monkeypatch):
     fake = FakeRedis()
     monkeypatch.setattr(redis_manager, "r", fake)
     monkeypatch.setattr(redis_manager.uuid, "uuid4", lambda: UUID("11111111-1111-1111-1111-111111111111"))
+    monkeypatch.setattr(redis_manager.orchestrator_agent, "build_mask_charsets", lambda: {})
+    monkeypatch.setattr(redis_manager.orchestrator_agent, "estimate_keyspace", lambda m, c: 10)
 
     batch_id = redis_manager.store_batch(["h"], mask="?a")
     assert batch_id == "11111111-1111-1111-1111-111111111111"
@@ -44,3 +60,5 @@ def test_store_and_get_batch(monkeypatch):
     assert data["batch_id"] == batch_id
     assert json.loads(data["hashes"]) == ["h"]
     assert data["mask"] == "?a"
+    assert data["keyspace"] == 10
+    assert batch_id in fake.smembers("hash_batches:h")

--- a/tests/test_server_found_map.py
+++ b/tests/test_server_found_map.py
@@ -64,6 +64,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), "Server"))
 
 import main
+import redis_manager
 
 class FakeRedis:
     def __init__(self):
@@ -71,6 +72,8 @@ class FakeRedis:
         self.lists = []
     def rpush(self, name, value):
         self.lists.append((name, value))
+    def lrem(self, name, count, value):
+        pass
     def hgetall(self, key):
         return {}
     def xack(self, *a, **kw):
@@ -95,6 +98,7 @@ async def call():
 def test_submit_founds_maps(monkeypatch):
     fake = FakeRedis()
     monkeypatch.setattr(main, "r", fake)
+    monkeypatch.setattr(redis_manager, "r", fake)
     monkeypatch.setattr(main, "verify_signature", lambda a, b, c: True)
     tmp = Path("/tmp/founds.txt")
     if tmp.exists():


### PR DESCRIPTION
## Summary
- record keyspace when storing batches and map hashes to batches
- track queued and completed keyspace ranges
- update orchestrator to log ranges and server to record progress when jobs finish
- adjust tests for new Redis interactions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68804f5d31888326b10fbdf513f0a3ff