### PR TITLE
Switch to aiohttp for hashes.com jobs

### DIFF
--- a/Server/main.py
+++ b/Server/main.py
@@ -324,7 +324,7 @@ async def fetch_and_store_jobs():
     try:
         from hashescom_client import fetch_jobs
 
-        jobs = fetch_jobs()
+        jobs = await fetch_jobs()
         for job in jobs:
             algo = str(job.get("algorithmName", "")).lower()
             if HASHES_ALGORITHMS and algo not in HASHES_ALGORITHMS:

--- a/tests/test_hashes_poll.py
+++ b/tests/test_hashes_poll.py
@@ -76,11 +76,14 @@ def test_fetch_and_store_jobs(monkeypatch):
     fake = FakeRedis()
     monkeypatch.setattr(main, 'r', fake)
     monkeypatch.setattr(main, 'HASHES_ALGORITHMS', ['md5'])
-    monkeypatch.setattr(hashescom_client, 'fetch_jobs', lambda: [{
-        'id': 8,
-        'algorithmName': 'MD5',
-        'currency': 'BTC',
-        'pricePerHash': '1'
-    }])
+    async def fake_fetch_jobs():
+        return [{
+            'id': 8,
+            'algorithmName': 'MD5',
+            'currency': 'BTC',
+            'pricePerHash': '1'
+        }]
+
+    monkeypatch.setattr(hashescom_client, 'fetch_jobs', fake_fetch_jobs)
     asyncio.run(run_once())
     assert 'hashes_job:8' in fake.store


### PR DESCRIPTION
## Summary
- use aiohttp to asynchronously fetch jobs from hashes.com
- await `fetch_jobs` in `fetch_and_store_jobs`
- update job polling test for async client

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68817014aa40832696f9848c38375437