### PR TITLE
Ensure thread-safe founds logging

### DIFF
--- a/Server/main.py
+++ b/Server/main.py
@@ -33,6 +33,7 @@ import hashlib
 import csv
 import io
 import tempfile
+from filelock import FileLock
 
 from waifus import assign_waifu
 from auth_utils import verify_signature, verify_signature_with_key
@@ -578,9 +579,11 @@ async def submit_founds(payload: dict):
                 continue
             r.hset("found:map", hash_str, password)
         try:
-            with FOUNDS_FILE.open("a", encoding="utf-8") as fh:
-                for line in payload["founds"]:
-                    fh.write(line + "\n")
+            lock = FileLock(str(FOUNDS_FILE) + ".lock")
+            with lock:
+                with FOUNDS_FILE.open("a", encoding="utf-8") as fh:
+                    for line in payload["founds"]:
+                        fh.write(line + "\n")
         except Exception:
             pass
 

--- a/Server/requirements.txt
+++ b/Server/requirements.txt
@@ -6,3 +6,4 @@ pydantic
 cryptography
 python-multipart
 psutil
+filelock

--- a/tests/test_server_found_map.py
+++ b/tests/test_server_found_map.py
@@ -3,6 +3,7 @@ import sys
 import os
 import types
 from pathlib import Path
+import threading
 
 # Stub FastAPI and Pydantic as in other server tests
 fastapi_stub = types.ModuleType("fastapi")
@@ -93,3 +94,40 @@ def test_submit_founds_maps(monkeypatch):
     assert fake.store["found:map"]["h1"] == "p1"
     assert fake.store["found:map"]["h2"] == "p2"
     assert tmp.read_text().splitlines() == ["h1:p1", "h2:p2"]
+
+
+def _thread_call(payload):
+    asyncio.run(main.submit_founds(payload))
+
+
+def test_submit_founds_thread_safe(monkeypatch):
+    fake = FakeRedis()
+    monkeypatch.setattr(main, "r", fake)
+    monkeypatch.setattr(redis_manager, "r", fake)
+    monkeypatch.setattr(main, "verify_signature", lambda a, b, c: True)
+    tmp = Path("/tmp/founds_thread.txt")
+    if tmp.exists():
+        tmp.unlink()
+    monkeypatch.setattr(main, "FOUNDS_FILE", tmp)
+
+    threads = []
+    lines = []
+    for i in range(5):
+        line = f"h{i}:p{i}"
+        lines.append(line)
+        payload = {
+            "worker_id": f"w{i}",
+            "batch_id": f"b{i}",
+            "founds": [line],
+            "signature": "s",
+        }
+        t = threading.Thread(target=_thread_call, args=(payload,))
+        threads.append(t)
+        t.start()
+
+    for t in threads:
+        t.join()
+
+    file_lines = tmp.read_text().splitlines()
+    assert set(file_lines) == set(lines)
+    assert len(file_lines) == len(lines)


### PR DESCRIPTION
## Summary
- lock the founds.txt file while writing results
- depend on filelock in server requirements
- test thread safety when multiple threads submit founds concurrently

## Testing
- `pip install -r Server/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882b1e776908326b757ac8a4b6d04db