### PR TITLE
Enable password/TLS for Redis clients

### DIFF
--- a/Server/README.md
+++ b/Server/README.md
@@ -260,6 +260,32 @@ environment variables or `~/.hashmancer/server_config.json`:
 If not provided, the defaults are `./` for `RESTORE_DIR` and
 `./restore_backups` for `BACKUP_DIR`.
 
+### Redis credentials
+
+If your Redis instance requires authentication or TLS, set these environment
+variables (or add the fields to `~/.hashmancer/server_config.json`):
+
+```json
+{
+  "redis_password": "s3cret",
+  "redis_ssl": true,
+  "redis_ssl_ca_cert": "/etc/redis/ca.pem",
+  "redis_ssl_cert": "/etc/redis/client.pem",
+  "redis_ssl_key": "/etc/redis/client.key"
+}
+```
+
+Minimal `redis.conf` snippet for TLS/ACLs:
+
+```conf
+port 0
+tls-port 6379
+requirepass s3cret
+tls-cert-file /etc/redis/server.pem
+tls-key-file /etc/redis/server.key
+tls-ca-cert-file /etc/redis/ca.pem
+```
+
 ### Portal API key
 
 To restrict access to the web dashboard set `"portal_key"` in

--- a/Server/redis_utils.py
+++ b/Server/redis_utils.py
@@ -10,12 +10,45 @@ def get_redis() -> redis.Redis:
     """Return a Redis connection using env vars or server_config.json."""
     host = os.getenv("REDIS_HOST", "localhost")
     port = int(os.getenv("REDIS_PORT", "6379"))
+    password = os.getenv("REDIS_PASSWORD")
+    use_ssl = os.getenv("REDIS_SSL", "0")
+    ssl_cert = os.getenv("REDIS_SSL_CERT")
+    ssl_key = os.getenv("REDIS_SSL_KEY")
+    ssl_ca = os.getenv("REDIS_SSL_CA_CERT")
     if CONFIG_FILE.exists():
         try:
             with open(CONFIG_FILE) as f:
                 cfg = json.load(f)
             host = os.getenv("REDIS_HOST", cfg.get("redis_host", host))
             port = int(os.getenv("REDIS_PORT", cfg.get("redis_port", port)))
+            password = os.getenv(
+                "REDIS_PASSWORD", cfg.get("redis_password", password)
+            )
+            use_ssl = os.getenv("REDIS_SSL", str(cfg.get("redis_ssl", use_ssl)))
+            ssl_cert = os.getenv(
+                "REDIS_SSL_CERT", cfg.get("redis_ssl_cert", ssl_cert)
+            )
+            ssl_key = os.getenv(
+                "REDIS_SSL_KEY", cfg.get("redis_ssl_key", ssl_key)
+            )
+            ssl_ca = os.getenv(
+                "REDIS_SSL_CA_CERT", cfg.get("redis_ssl_ca_cert", ssl_ca)
+            )
         except Exception:
             pass
-    return redis.Redis(host=host, port=port, decode_responses=True)
+    options: dict[str, str | int | bool] = {
+        "host": host,
+        "port": port,
+        "decode_responses": True,
+    }
+    if password:
+        options["password"] = password
+    if str(use_ssl).lower() in {"1", "true", "yes"}:
+        options["ssl"] = True
+        if ssl_ca:
+            options["ssl_ca_certs"] = ssl_ca
+        if ssl_cert:
+            options["ssl_certfile"] = ssl_cert
+        if ssl_key:
+            options["ssl_keyfile"] = ssl_key
+    return redis.Redis(**options)

--- a/Worker/README.md
+++ b/Worker/README.md
@@ -12,13 +12,26 @@ Both NVIDIA, AMD, and Intel GPUs are supported.
 - `hashmancer_worker/gpu_sidecar.py` – fetches batches via `/get_batch` and submits results
 
 The worker expects a local Redis instance for caching. Configure `REDIS_HOST` and
-`REDIS_PORT`. Point to the server with `SERVER_URL` and provide signing keys via
-`PRIVATE_KEY_PATH` and `PUBLIC_KEY_PATH`. The status heartbeat interval can be
-customized with `STATUS_INTERVAL` (seconds).
+`REDIS_PORT`. Provide a password with `REDIS_PASSWORD` and set `REDIS_SSL=1` to
+enable TLS. Certificate paths can be specified with `REDIS_SSL_CA_CERT`,
+`REDIS_SSL_CERT`, and `REDIS_SSL_KEY`. Point to the server with `SERVER_URL` and
+provide signing keys via `PRIVATE_KEY_PATH` and `PUBLIC_KEY_PATH`. The status
+heartbeat interval can be customized with `STATUS_INTERVAL` (seconds).
 
 Run `python3 ../setup.py --worker` from the repository root to install
 dependencies and configure the worker.  Passing `--server-ip` skips broadcast
 discovery.
+
+Minimal `redis.conf` for a password-protected TLS instance:
+
+```conf
+port 0
+tls-port 6379
+requirepass s3cret
+tls-cert-file /etc/redis/server.pem
+tls-key-file /etc/redis/server.key
+tls-ca-cert-file /etc/redis/ca.pem
+```
 
 Start a worker with:
 

--- a/Worker/hashmancer_worker/gpu_sidecar.py
+++ b/Worker/hashmancer_worker/gpu_sidecar.py
@@ -19,8 +19,29 @@ from darkling import statistics
 
 REDIS_HOST = os.getenv("REDIS_HOST", "localhost")
 REDIS_PORT = int(os.getenv("REDIS_PORT", "6379"))
+REDIS_PASSWORD = os.getenv("REDIS_PASSWORD")
+REDIS_SSL = os.getenv("REDIS_SSL", "0")
+REDIS_SSL_CERT = os.getenv("REDIS_SSL_CERT")
+REDIS_SSL_KEY = os.getenv("REDIS_SSL_KEY")
+REDIS_SSL_CA_CERT = os.getenv("REDIS_SSL_CA_CERT")
 
-r = redis.Redis(host=REDIS_HOST, port=REDIS_PORT, decode_responses=True)
+redis_opts: dict[str, str | int | bool] = {
+    "host": REDIS_HOST,
+    "port": REDIS_PORT,
+    "decode_responses": True,
+}
+if REDIS_PASSWORD:
+    redis_opts["password"] = REDIS_PASSWORD
+if str(REDIS_SSL).lower() in {"1", "true", "yes"}:
+    redis_opts["ssl"] = True
+    if REDIS_SSL_CA_CERT:
+        redis_opts["ssl_ca_certs"] = REDIS_SSL_CA_CERT
+    if REDIS_SSL_CERT:
+        redis_opts["ssl_certfile"] = REDIS_SSL_CERT
+    if REDIS_SSL_KEY:
+        redis_opts["ssl_keyfile"] = REDIS_SSL_KEY
+
+r = redis.Redis(**redis_opts)
 
 
 def _safe_redis_call(func, *args, default=None, **kwargs):


### PR DESCRIPTION
## Summary
- support Redis passwords and TLS certificates for server and worker
- document new environment variables and a redis.conf snippet in both READMEs

## Testing
- `pip install requests filelock cryptography argon2-cffi pytest-asyncio`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882beb5bc0483269c1fb9684bc45b5c