### PR TITLE
Improve Redis security docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,11 @@ add these fields along with default training parameters:
   "llm_train_learning_rate": 0.0001
 }
 ```
+
+### Redis security
+
+Redis should only listen on the loopback interface. Add `bind 127.0.0.1` to
+`redis.conf` so the service is not exposed to the LAN. When remote workers need
+access, restrict the port to their IPs with firewall rules (`iptables` or
+`ufw`). It's best to place Redis behind a VPN or require TLS with client
+certificates when exposing it over the internet.

--- a/Server/README.md
+++ b/Server/README.md
@@ -286,6 +286,29 @@ tls-key-file /etc/redis/server.key
 tls-ca-cert-file /etc/redis/ca.pem
 ```
 
+### Binding and Firewall Rules
+
+By default Redis should only listen on localhost. Add `bind 127.0.0.1` to
+`redis.conf` (and optionally `protected-mode yes`) so the service is not
+reachable from other hosts. When you need to allow remote workers, open the
+port only for their IP addresses.
+
+Example `iptables` commands:
+
+```bash
+sudo iptables -A INPUT -p tcp --dport 6379 -s <worker-ip> -j ACCEPT
+sudo iptables -A INPUT -p tcp --dport 6379 -j DROP
+```
+
+Using `ufw` instead:
+
+```bash
+sudo ufw allow from <worker-ip> to any port 6379 proto tcp
+```
+
+For remote deployments it's strongly recommended to run Redis behind a VPN or
+enable TLS with client certificates so each worker authenticates securely.
+
 ### Portal API key
 
 To restrict access to the web dashboard set `"portal_key"` in


### PR DESCRIPTION
## Summary
- document Redis security best practices in README
- detail binding Redis to localhost and limiting worker IPs

## Testing
- `pip install -r Server/requirements-dev.txt`
- `pytest -q` *(fails: 23 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6882c810a44c8326bcced0493a7779d6