### PR TITLE
Cache private key on first use

### DIFF
--- a/Server/signing_utils.py
+++ b/Server/signing_utils.py
@@ -29,9 +29,10 @@ except FileNotFoundError:
 
 def sign_message(message: str) -> str:
     """Return a base64 signature for ``message`` using the cached key."""
+    global _PRIVATE_KEY
     key = _PRIVATE_KEY
     if key is None:
-        key = load_private_key()
+        _PRIVATE_KEY = key = load_private_key()
     signature = key.sign(
         message.encode(), padding.PKCS1v15(), hashes.SHA256()
     )

--- a/Worker/hashmancer_worker/crypto_utils.py
+++ b/Worker/hashmancer_worker/crypto_utils.py
@@ -41,9 +41,10 @@ def load_public_key_pem() -> str:
 
 def sign_message(message: str) -> str:
     """Return a base64 signature for the provided message."""
+    global _PRIVATE_KEY
     key = _PRIVATE_KEY
     if key is None:
-        key = load_private_key()
+        _PRIVATE_KEY = key = load_private_key()
     signature = key.sign(
         message.encode(), padding.PKCS1v15(), hashes.SHA256()
     )

--- a/tests/test_sign_message_cache.py
+++ b/tests/test_sign_message_cache.py
@@ -1,0 +1,63 @@
+import os
+import sys
+import importlib
+from pathlib import Path
+
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives import serialization
+
+ROOT = os.path.dirname(os.path.dirname(__file__))
+sys.path.insert(0, ROOT)
+sys.path.insert(0, os.path.join(ROOT, "Server"))
+
+
+def _make_key(path: Path) -> Path:
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    data = key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    )
+    path.write_bytes(data)
+    return path
+
+
+def _run_test(module_name: str, tmp_path: Path, monkeypatch, env_var: str | None = None, path_attr: str | None = None):
+    key_path = _make_key(tmp_path / "key.pem")
+    if env_var:
+        monkeypatch.setenv(env_var, str(key_path))
+    module = importlib.import_module(module_name)
+    module = importlib.reload(module)
+    if path_attr:
+        setattr(module, path_attr, str(key_path))
+    module._PRIVATE_KEY = None
+
+    calls = []
+    orig_open = open
+
+    def counting_open(*args, **kwargs):
+        calls.append(args[0])
+        return orig_open(*args, **kwargs)
+
+    monkeypatch.setattr("builtins.open", counting_open)
+    module.sign_message("one")
+    module.sign_message("two")
+    assert len(calls) == 1
+
+
+def test_worker_sign_message_load_once(monkeypatch, tmp_path):
+    _run_test(
+        "Worker.hashmancer_worker.crypto_utils",
+        tmp_path,
+        monkeypatch,
+        env_var="PRIVATE_KEY_PATH",
+    )
+
+
+def test_server_sign_message_load_once(monkeypatch, tmp_path):
+    _run_test(
+        "Server.signing_utils",
+        tmp_path,
+        monkeypatch,
+        path_attr="KEY_PATH",
+    )


### PR DESCRIPTION
## Summary
- cache `_PRIVATE_KEY` on first call to `sign_message`
- test that key file is opened only once

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68839b4c19788326a3bb13c4f4f20e98