### PR TITLE
Add timestamp-based signature verification

### DIFF
--- a/Server/signing_utils.py
+++ b/Server/signing_utils.py
@@ -6,6 +6,7 @@ operations.
 """
 
 import base64
+import time
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding
 
@@ -27,13 +28,16 @@ except FileNotFoundError:
     _PRIVATE_KEY = None
 
 
-def sign_message(message: str) -> str:
-    """Return a base64 signature for ``message`` using the cached key."""
+def sign_message(message: str, timestamp: int | None = None) -> str:
+    """Return a base64 signature for ``message`` at ``timestamp`` using the cached key."""
     global _PRIVATE_KEY
+    if timestamp is None:
+        timestamp = int(time.time())
     key = _PRIVATE_KEY
     if key is None:
         _PRIVATE_KEY = key = load_private_key()
+    payload = f"{message}|{timestamp}"
     signature = key.sign(
-        message.encode(), padding.PKCS1v15(), hashes.SHA256()
+        payload.encode(), padding.PKCS1v15(), hashes.SHA256()
     )
     return base64.b64encode(signature).decode()

--- a/Worker/hashmancer_worker/bios_flasher.py
+++ b/Worker/hashmancer_worker/bios_flasher.py
@@ -239,8 +239,10 @@ class GPUFlashManager(threading.Thread):
             "worker_id": self.worker_id,
             "gpu_uuid": gpu_uuid,
             "success": success,
-            "signature": sign_message(self.worker_id),
+            "timestamp": int(time.time()),
+            "signature": None,
         }
+        payload["signature"] = sign_message(self.worker_id, payload["timestamp"])
         try:
             requests.post(f"{self.server_url}/flash_result", json=payload, timeout=5)
         except Exception:
@@ -249,9 +251,11 @@ class GPUFlashManager(threading.Thread):
     def run(self):
         while self.running:
             try:
+                ts = int(time.time())
                 params = {
                     "worker_id": self.worker_id,
-                    "signature": sign_message(self.worker_id),
+                    "timestamp": ts,
+                    "signature": sign_message(self.worker_id, ts),
                 }
                 resp = requests.get(
                     f"{self.server_url}/get_flash_task", params=params, timeout=5

--- a/tests/test_auth_middleware.py
+++ b/tests/test_auth_middleware.py
@@ -244,11 +244,12 @@ def test_root_auth_allows_with_key(monkeypatch):
 def test_portal_ws_reports_status(monkeypatch):
     fake_r = FakeRedis()
     monkeypatch.setattr(main, "r", fake_r)
-    monkeypatch.setattr(main, "verify_signature", lambda a, b, c: True)
+    monkeypatch.setattr(main, "verify_signature", lambda *a: True)
 
     class Req:
         name = "alpha"
         status = "busy"
+        timestamp = 0
         signature = "s"
 
     asyncio.run(main.set_worker_status(Req()))

--- a/tests/test_flash_queue.py
+++ b/tests/test_flash_queue.py
@@ -98,7 +98,7 @@ class FakeRedis:
 def test_flash_queue_on_register(monkeypatch):
     fake = FakeRedis()
     monkeypatch.setattr(main, "r", fake)
-    monkeypatch.setattr(main, "verify_signature_with_key", lambda a, b, c: True)
+    monkeypatch.setattr(main, "verify_signature_with_key", lambda *a: True)
     monkeypatch.setattr(main, "assign_waifu", lambda s: "Agent")
     monkeypatch.setattr(main, "LOW_BW_ENGINE", "hashcat")
 
@@ -106,6 +106,7 @@ def test_flash_queue_on_register(monkeypatch):
         worker_id = "id"
         signature = "s"
         pubkey = "p"
+        timestamp = 0
         mode = "eco"
         provider = "on-prem"
         hardware = {"gpus": [{"uuid": "u1", "model": "RTX 3080", "index": 0}]}

--- a/tests/test_gpu_flasher.py
+++ b/tests/test_gpu_flasher.py
@@ -24,7 +24,7 @@ def test_process_task(monkeypatch):
     monkeypatch.setattr(bios_flasher.requests, "post", fake_post)
     monkeypatch.setattr(bios_flasher, "md5_speed", lambda: 1.0)
     monkeypatch.setattr(bios_flasher, "apply_flash_settings", lambda g, s: True)
-    monkeypatch.setattr(bios_flasher, "sign_message", lambda x: "sig")
+    monkeypatch.setattr(bios_flasher, "sign_message", lambda *a: "sig")
 
     mgr = bios_flasher.GPUFlashManager("w", "http://sv", [{"uuid": "u1", "index": 0}])
     mgr.process_task("u1", {"vendor": "nvidia"})

--- a/tests/test_gpu_sidecar.py
+++ b/tests/test_gpu_sidecar.py
@@ -59,7 +59,7 @@ def test_run_hashcat(monkeypatch):
 
     monkeypatch.setattr(gpu_sidecar.subprocess, "Popen", fake_popen)
     monkeypatch.setattr(gpu_sidecar.requests, "post", lambda *a, **k: None)
-    monkeypatch.setattr(gpu_sidecar, "sign_message", lambda x: "sig")
+    monkeypatch.setattr(gpu_sidecar, "sign_message", lambda *a: "sig")
 
     batch = {
         "batch_id": "job1",
@@ -105,7 +105,7 @@ def test_darkling_engine_selected(monkeypatch):
 
     monkeypatch.setattr(gpu_sidecar.subprocess, "Popen", fake_popen)
     monkeypatch.setattr(gpu_sidecar.requests, "post", lambda *a, **k: None)
-    monkeypatch.setattr(gpu_sidecar, "sign_message", lambda x: "sig")
+    monkeypatch.setattr(gpu_sidecar, "sign_message", lambda *a: "sig")
 
     batch = {
         "batch_id": "job2",
@@ -136,7 +136,7 @@ def test_custom_mask_charsets(monkeypatch):
 
     monkeypatch.setattr(gpu_sidecar.subprocess, "Popen", fake_popen)
     monkeypatch.setattr(gpu_sidecar.requests, "post", lambda *a, **k: None)
-    monkeypatch.setattr(gpu_sidecar, "sign_message", lambda x: "sig")
+    monkeypatch.setattr(gpu_sidecar, "sign_message", lambda *a: "sig")
 
     batch = {
         "batch_id": "job7",
@@ -166,7 +166,7 @@ def test_reuse_preloaded_charsets(monkeypatch):
 
     monkeypatch.setattr(gpu_sidecar.subprocess, "Popen", fake_popen)
     monkeypatch.setattr(gpu_sidecar.requests, "post", lambda *a, **k: None)
-    monkeypatch.setattr(gpu_sidecar, "sign_message", lambda x: "sig")
+    monkeypatch.setattr(gpu_sidecar, "sign_message", lambda *a: "sig")
 
     batch = {
         "batch_id": "job8",
@@ -202,7 +202,7 @@ def test_power_limit_nvidia(monkeypatch):
     monkeypatch.setattr(gpu_sidecar.subprocess, "check_call", fake_check_call)
     monkeypatch.setattr(gpu_sidecar.subprocess, "Popen", fake_popen)
     monkeypatch.setattr(gpu_sidecar.requests, "post", lambda *a, **k: None)
-    monkeypatch.setattr(gpu_sidecar, "sign_message", lambda x: "sig")
+    monkeypatch.setattr(gpu_sidecar, "sign_message", lambda *a: "sig")
 
     batch = {
         "batch_id": "job3",
@@ -239,7 +239,7 @@ def test_power_limit_rocm(monkeypatch):
     monkeypatch.setattr(gpu_sidecar.subprocess, "check_call", fake_check_call)
     monkeypatch.setattr(gpu_sidecar.subprocess, "Popen", fake_popen)
     monkeypatch.setattr(gpu_sidecar.requests, "post", lambda *a, **k: None)
-    monkeypatch.setattr(gpu_sidecar, "sign_message", lambda x: "sig")
+    monkeypatch.setattr(gpu_sidecar, "sign_message", lambda *a: "sig")
 
     batch = {
         "batch_id": "job4",
@@ -276,7 +276,7 @@ def test_power_overdrive_rocm(monkeypatch):
     monkeypatch.setattr(gpu_sidecar.subprocess, "check_call", fake_check_call)
     monkeypatch.setattr(gpu_sidecar.subprocess, "Popen", fake_popen)
     monkeypatch.setattr(gpu_sidecar.requests, "post", lambda *a, **k: None)
-    monkeypatch.setattr(gpu_sidecar, "sign_message", lambda x: "sig")
+    monkeypatch.setattr(gpu_sidecar, "sign_message", lambda *a: "sig")
 
     batch = {
         "batch_id": "job4b",
@@ -312,7 +312,7 @@ def test_power_limit_intel(monkeypatch):
     monkeypatch.setattr(gpu_sidecar.subprocess, "check_call", fake_check_call)
     monkeypatch.setattr(gpu_sidecar.subprocess, "Popen", fake_popen)
     monkeypatch.setattr(gpu_sidecar.requests, "post", lambda *a, **k: None)
-    monkeypatch.setattr(gpu_sidecar, "sign_message", lambda x: "sig")
+    monkeypatch.setattr(gpu_sidecar, "sign_message", lambda *a: "sig")
 
     batch = {
         "batch_id": "job5",
@@ -344,7 +344,7 @@ def test_sidecar_run_executes_job(monkeypatch):
         return DummyResp({"batch_id": "job6", "hashes": "[]", "mask": "", "attack_mode": "mask"})
 
     monkeypatch.setattr(gpu_sidecar.requests, "get", fake_get)
-    monkeypatch.setattr(gpu_sidecar, "sign_message", lambda x: "sig")
+    monkeypatch.setattr(gpu_sidecar, "sign_message", lambda *a: "sig")
     monkeypatch.setattr(gpu_sidecar, "r", FakeRedis())
 
     executed = {}
@@ -425,7 +425,7 @@ def test_darkling_mask_length_limit(monkeypatch):
 
     monkeypatch.setattr(gpu_sidecar.subprocess, "Popen", fake_popen)
     monkeypatch.setattr(gpu_sidecar.requests, "post", lambda *a, **k: None)
-    monkeypatch.setattr(gpu_sidecar, "sign_message", lambda x: "sig")
+    monkeypatch.setattr(gpu_sidecar, "sign_message", lambda *a: "sig")
 
     batch = {
         "batch_id": "joblen",
@@ -454,7 +454,7 @@ def test_darkling_hash_batching(monkeypatch):
 
     monkeypatch.setattr(gpu_sidecar.GPUSidecar, "_run_engine", fake_run_engine)
     monkeypatch.setattr(gpu_sidecar.requests, "post", lambda *a, **k: None)
-    monkeypatch.setattr(gpu_sidecar, "sign_message", lambda x: "sig")
+    monkeypatch.setattr(gpu_sidecar, "sign_message", lambda *a: "sig")
 
     hashes = [f"h{i}" for i in range(gpu_sidecar.MAX_HASHES + 5)]
     batch = {

--- a/tests/test_server_found_map.py
+++ b/tests/test_server_found_map.py
@@ -75,6 +75,7 @@ async def call():
         "worker_id": "w",
         "batch_id": "b",
         "founds": ["h1:p1", "h2:p2"],
+        "timestamp": 0,
         "signature": "s",
     }
     return await main.submit_founds(payload)
@@ -84,7 +85,7 @@ def test_submit_founds_maps(monkeypatch):
     fake = FakeRedis()
     monkeypatch.setattr(main, "r", fake)
     monkeypatch.setattr(redis_manager, "r", fake)
-    monkeypatch.setattr(main, "verify_signature", lambda a, b, c: True)
+    monkeypatch.setattr(main, "verify_signature", lambda *a: True)
     tmp = Path("/tmp/founds.txt")
     if tmp.exists():
         tmp.unlink()
@@ -104,7 +105,7 @@ def test_submit_founds_thread_safe(monkeypatch):
     fake = FakeRedis()
     monkeypatch.setattr(main, "r", fake)
     monkeypatch.setattr(redis_manager, "r", fake)
-    monkeypatch.setattr(main, "verify_signature", lambda a, b, c: True)
+    monkeypatch.setattr(main, "verify_signature", lambda *a: True)
     tmp = Path("/tmp/founds_thread.txt")
     if tmp.exists():
         tmp.unlink()
@@ -119,6 +120,7 @@ def test_submit_founds_thread_safe(monkeypatch):
             "worker_id": f"w{i}",
             "batch_id": f"b{i}",
             "founds": [line],
+            "timestamp": 0,
             "signature": "s",
         }
         t = threading.Thread(target=_thread_call, args=(payload,))

--- a/tests/test_server_get_batch.py
+++ b/tests/test_server_get_batch.py
@@ -117,9 +117,9 @@ def test_get_batch_returns_batch_id(monkeypatch):
     fake.store["worker:worker"] = {"low_bw_engine": "hashcat"}
     monkeypatch.setattr(main, "r", fake)
     monkeypatch.setattr(redis_manager, "r", fake)
-    monkeypatch.setattr(main, "verify_signature", lambda a, b, c: True)
+    monkeypatch.setattr(main, "verify_signature", lambda *a: True)
 
-    resp = asyncio.run(main.get_batch("worker", "sig"))
+    resp = asyncio.run(main.get_batch("worker", 0, "sig"))
 
     assert resp["batch_id"] == "batch1"
     assert fake.store["worker:worker"]["last_batch"] == "batch1"
@@ -134,8 +134,9 @@ def test_get_batch_returns_batch_id(monkeypatch):
         "batch_id": resp["batch_id"],
         "job_id": resp["job_id"],
         "msg_id": resp["msg_id"],
+        "timestamp": 0,
         "signature": "sig",
     }
-    monkeypatch.setattr(main, "verify_signature", lambda a, b, c: True)
+    monkeypatch.setattr(main, "verify_signature", lambda *a: True)
     asyncio.run(main.submit_no_founds(payload))
     assert fake.ack_args == (main.JOB_STREAM, main.HTTP_GROUP, "1-0")

--- a/tests/test_server_register.py
+++ b/tests/test_server_register.py
@@ -76,6 +76,7 @@ def test_register_worker_policy(monkeypatch):
     monkeypatch.setattr(padding, 'PKCS1v15', lambda: None)
     monkeypatch.setattr(hashes, 'SHA256', lambda: None)
     monkeypatch.setattr(base64, 'b64decode', lambda s: b'')
+    monkeypatch.setattr(main, 'verify_signature_with_key', lambda *a: True)
     monkeypatch.setattr(main, 'assign_waifu', lambda s: 'Agent')
     monkeypatch.setattr(main, 'LOW_BW_ENGINE', 'darkling')
 
@@ -83,6 +84,7 @@ def test_register_worker_policy(monkeypatch):
         worker_id = 'id'
         signature = 's'
         pubkey = 'p'
+        timestamp = 0
         mode = 'eco'
         provider = 'on-prem'
         hardware = {}

--- a/tests/test_server_submit_benchmark.py
+++ b/tests/test_server_submit_benchmark.py
@@ -62,13 +62,14 @@ class FakeRedis:
 def test_submit_benchmark(monkeypatch):
     fake = FakeRedis()
     monkeypatch.setattr(main, 'r', fake)
-    monkeypatch.setattr(main, 'verify_signature', lambda a, b, c: True)
+    monkeypatch.setattr(main, 'verify_signature', lambda *a: True)
 
     class Req:
         worker_id = 'w1'
         gpu_uuid = 'g1'
         engine = 'hashcat'
         hashrates = {'MD5': 1.0, 'SHA1': 2.0, 'NTLM': 3.0}
+        timestamp = 0
         signature = 's'
 
     resp = asyncio.run(main.submit_benchmark(Req()))

--- a/tests/test_timestamp_signatures.py
+++ b/tests/test_timestamp_signatures.py
@@ -1,0 +1,28 @@
+import importlib
+import types
+import sys
+
+sys.path.insert(0, 'Server')
+
+import auth_utils
+
+
+def _setup(monkeypatch, current_time):
+    monkeypatch.setattr(auth_utils.time, 'time', lambda: current_time)
+    class Key:
+        def verify(self, *a, **k):
+            pass
+    monkeypatch.setattr(auth_utils, 'get_worker_pubkey', lambda wid: Key())
+    monkeypatch.setattr(auth_utils.base64, 'b64decode', lambda s: b'')
+    monkeypatch.setattr(auth_utils.padding, 'PKCS1v15', lambda: None)
+    monkeypatch.setattr(auth_utils.hashes, 'SHA256', lambda: None)
+
+
+def test_valid_timestamp(monkeypatch):
+    _setup(monkeypatch, 100)
+    assert auth_utils.verify_signature('w', 'm', 100, 's')
+
+
+def test_expired_timestamp(monkeypatch):
+    _setup(monkeypatch, 100)
+    assert not auth_utils.verify_signature('w', 'm', 50, 's')

--- a/tests/test_worker_agent.py
+++ b/tests/test_worker_agent.py
@@ -38,7 +38,7 @@ def test_register_worker_success(monkeypatch):
 
     monkeypatch.setattr(worker_agent.requests, "post", mock_post)
     monkeypatch.setattr(worker_agent, "load_public_key_pem", lambda: "PUB")
-    monkeypatch.setattr(worker_agent, "sign_message", lambda x: "sig")
+    monkeypatch.setattr(worker_agent, "sign_message", lambda *a: "sig")
 
     gpus = [
         {
@@ -87,7 +87,7 @@ def test_register_worker_retry(monkeypatch):
         lambda url, json=None, timeout=None: DummyResp({"status": "ok", "waifu": "W"}),
     )
     monkeypatch.setattr(worker_agent, "load_public_key_pem", lambda: "PUB")
-    monkeypatch.setattr(worker_agent, "sign_message", lambda x: "sig")
+    monkeypatch.setattr(worker_agent, "sign_message", lambda *a: "sig")
 
     sleeps = []
     monkeypatch.setattr(worker_agent.time, "sleep", lambda s: sleeps.append(s))
@@ -145,7 +145,7 @@ def test_benchmark_low_bw_gpu(monkeypatch):
         worker_agent, "run_hashcat_benchmark", lambda g, engine="hashcat": {}
     )
     monkeypatch.setattr(worker_agent.requests, "post", fake_post)
-    monkeypatch.setattr(worker_agent, "sign_message", lambda x: "sig")
+    monkeypatch.setattr(worker_agent, "sign_message", lambda *a: "sig")
 
     class DummySidecar:
         def __init__(
@@ -221,7 +221,7 @@ def test_prob_order_from_server(monkeypatch):
         worker_agent, "run_hashcat_benchmark", lambda g, engine="hashcat": {}
     )
     monkeypatch.setattr(worker_agent.requests, "post", fake_post)
-    monkeypatch.setattr(worker_agent, "sign_message", lambda x: "sig")
+    monkeypatch.setattr(worker_agent, "sign_message", lambda *a: "sig")
 
     class DummySidecar:
         def __init__(


### PR DESCRIPTION
## Summary
- sign messages with timestamps to prevent replay attacks
- validate timestamp in auth utils
- pass timestamp in worker requests
- accept timestamp parameters on server endpoints
- test timestamp validation and update existing tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68839f833f8c83269da0d0fe48af8aa0