### PR TITLE
Add trusted worker key configuration

### DIFF
--- a/Server/README.md
+++ b/Server/README.md
@@ -367,6 +367,25 @@ Specify a list of origins permitted for CORS requests by adding
 
 If omitted, all origins are accepted.
 
+### Trusted worker keys
+
+Restrict worker registration to known public keys by listing SHA-256 fingerprints
+in a file and referencing it with `"trusted_keys_file"`:
+
+```json
+{
+  "trusted_keys_file": "/opt/hashmancer/trusted_keys.txt"
+}
+```
+
+Generate a fingerprint from a PEM key with:
+
+```bash
+openssl rsa -pubin -in worker_public_key.pem -outform der | sha256sum | cut -d' ' -f1 >> /opt/hashmancer/trusted_keys.txt
+```
+
+Only keys matching a fingerprint in this file are allowed to register.
+
 ## 🌐 Reverse Proxy Setup
 
 When exposing Hashmancer to the internet it's best to place a TLS-enabled

--- a/Server/auth_utils.py
+++ b/Server/auth_utils.py
@@ -3,6 +3,7 @@ import redis
 from redis_utils import get_redis
 import logging
 import time
+import hashlib
 from cryptography.hazmat.primitives.asymmetric import padding
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.exceptions import InvalidSignature
@@ -74,3 +75,13 @@ def verify_signature_with_key(pubkey_pem: str, payload: str, timestamp: int, sig
     except Exception as e:
         logging.error(f"Verification error: {e}")
         return False
+
+
+def fingerprint_public_key(pubkey_pem: str) -> str:
+    """Return a SHA-256 fingerprint for the given public key."""
+    key = serialization.load_pem_public_key(pubkey_pem.encode())
+    der = key.public_bytes(
+        serialization.Encoding.DER,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return hashlib.sha256(der).hexdigest()


### PR DESCRIPTION
## Summary
- add SHA-256 fingerprint check for worker registration
- load fingerprints from `trusted_keys_file` in configuration
- document trusted key setup in Server README
- test allowed and disallowed worker keys

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883a4f1daf88326a5b691ce82b93033