### PR TITLE
Add automatic key generation for signing helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Run `python3 setup.py` from the repository root to configure either a server or
 worker.  Use `--server` or `--worker` flags to skip the prompt.  A worker can
 also supply `--server-ip` to skip auto-discovery. After setup, run
 `python3 setup.py --upgrade` to pull the latest version and update dependencies.
+Both components generate their RSA signing keys automatically the first time
+they run if no key files are present.
 
 ## Thread Safety
 

--- a/Server/README.md
+++ b/Server/README.md
@@ -74,6 +74,7 @@ This will:
 - Install a systemd service
 - Optionally enable a UDP broadcast so workers can auto-discover the server
 - Generate a random portal passkey and an initial admin token
+- Create a 4096-bit server signing key if one doesn't exist
 
 3. Start the server (if not done via systemd):
 

--- a/Server/signing_utils.py
+++ b/Server/signing_utils.py
@@ -7,15 +7,33 @@ operations.
 
 import base64
 import time
+from pathlib import Path
 from cryptography.hazmat.primitives import hashes, serialization
-from cryptography.hazmat.primitives.asymmetric import padding
+from cryptography.hazmat.primitives.asymmetric import padding, rsa
 
 KEY_PATH = "./keys/private_key.pem"
 
 
+def generate_private_key() -> rsa.RSAPrivateKey:
+    """Generate a 4096-bit RSA private key and save it to ``KEY_PATH``."""
+    key = rsa.generate_private_key(public_exponent=65537, key_size=4096)
+    priv_bytes = key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    )
+    path = Path(KEY_PATH)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(priv_bytes)
+    return key
+
+
 def load_private_key():
-    with open(KEY_PATH, "rb") as f:
-        key_data = f.read()
+    try:
+        with open(KEY_PATH, "rb") as f:
+            key_data = f.read()
+    except FileNotFoundError:
+        return generate_private_key()
     return serialization.load_pem_private_key(key_data, password=None)
 
 

--- a/Worker/README.md
+++ b/Worker/README.md
@@ -17,8 +17,9 @@ the server's Redis host so the worker can retrieve the cached wordlist.
 Provide a password with `REDIS_PASSWORD` and set `REDIS_SSL=1` to enable TLS.
 Certificate paths can be specified with `REDIS_SSL_CA_CERT`, `REDIS_SSL_CERT`,
 and `REDIS_SSL_KEY`. Point to the server with `SERVER_URL` and provide signing
-keys via `PRIVATE_KEY_PATH` and `PUBLIC_KEY_PATH`. The status heartbeat
-interval can be customized with `STATUS_INTERVAL` (seconds).
+keys via `PRIVATE_KEY_PATH` and `PUBLIC_KEY_PATH`. If these files do not exist
+the worker will create a new 4096-bit RSA pair on first use. The status
+heartbeat interval can be customized with `STATUS_INTERVAL` (seconds).
 
 Run `python3 ../setup.py --worker` from the repository root to install
 dependencies and configure the worker.  Passing `--server-ip` skips broadcast
@@ -87,8 +88,10 @@ HASHCAT_WORKLOAD=4 HASHCAT_OPTIMIZED=1 python -m hashmancer_worker.worker_agent
 
 ## Generating signing keys
 
-To sign requests sent to the server you need an RSA key pair.  Create the keys
-and store them under `~/.hashmancer` so the worker can load them automatically.
+The worker automatically generates a 4096-bit RSA key pair on first run if
+`PRIVATE_KEY_PATH` and `PUBLIC_KEY_PATH` do not exist.  You can also create the
+keys manually and store them under `~/.hashmancer` so the worker loads them
+at startup.
 
 Using `ssh-keygen`:
 

--- a/tests/test_sign_message_generation.py
+++ b/tests/test_sign_message_generation.py
@@ -1,0 +1,50 @@
+import os
+import sys
+import importlib
+from pathlib import Path
+
+ROOT = os.path.dirname(os.path.dirname(__file__))
+sys.path.insert(0, ROOT)
+sys.path.insert(0, os.path.join(ROOT, "Server"))
+
+
+def _run_worker(tmp_path: Path):
+    priv = tmp_path / "nested" / "worker_priv.pem"
+    pub = tmp_path / "nested" / "worker_pub.pem"
+    os.environ["PRIVATE_KEY_PATH"] = str(priv)
+    os.environ["PUBLIC_KEY_PATH"] = str(pub)
+    module = importlib.import_module("Worker.hashmancer_worker.crypto_utils")
+    module = importlib.reload(module)
+    module._PRIVATE_KEY = None
+    module.sign_message("msg")
+    assert priv.exists()
+    assert pub.exists()
+
+
+def _run_server(tmp_path: Path, monkeypatch):
+    priv = tmp_path / "srv" / "server_priv.pem"
+
+    # Prevent default path from being created during import
+    open_orig = open
+
+    def fail_default(path, *a, **kw):
+        if path == "./keys/private_key.pem":
+            raise FileNotFoundError
+        return open_orig(path, *a, **kw)
+
+    monkeypatch.setattr("builtins.open", fail_default)
+    module = importlib.import_module("Server.signing_utils")
+    module = importlib.reload(module)
+    monkeypatch.setattr("builtins.open", open_orig)
+    module.KEY_PATH = str(priv)
+    module._PRIVATE_KEY = None
+    module.sign_message("msg")
+    assert priv.exists()
+
+
+def test_worker_sign_message_generates_keys(tmp_path):
+    _run_worker(tmp_path)
+
+
+def test_server_sign_message_generates_key(monkeypatch, tmp_path):
+    _run_server(tmp_path, monkeypatch)


### PR DESCRIPTION
## Summary
- create RSA helper in `crypto_utils` and generate keys when missing
- mirror helper in `Server/signing_utils`
- generate worker/server keys on first use
- note automatic key creation in documentation
- test that `sign_message()` produces key files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883b06e3660832691f5ffa74e143b4b