### PR TITLE
Add priority queue for hash batches

### DIFF
--- a/tests/test_dispatch_loop.py
+++ b/tests/test_dispatch_loop.py
@@ -34,6 +34,7 @@ sys.modules.setdefault('fastapi.middleware.cors', cors_stub)
 
 resp_stub = types.ModuleType('fastapi.responses')
 resp_stub.HTMLResponse = object
+resp_stub.FileResponse = object
 sys.modules.setdefault('fastapi.responses', resp_stub)
 
 pydantic_stub = types.ModuleType('pydantic')
@@ -58,6 +59,7 @@ class FakeRedis:
         self.jobs = {}
         self.streams = []
         self.lists = {}
+        self.prio = {}
     def rpop(self, name):
         return self.queue.pop(0) if self.queue else None
     def hgetall(self, key):
@@ -74,6 +76,13 @@ class FakeRedis:
         lst = self.lists.get(name, [])
         while value in lst:
             lst.remove(value)
+    def zadd(self, name, mapping):
+        self.prio.update(mapping)
+    def zrevrange(self, name, start, end):
+        ordered = sorted(self.prio.items(), key=lambda x: -x[1])
+        return [k for k, _ in ordered[start:end+1]]
+    def zrem(self, name, member):
+        self.prio.pop(member, None)
     def scan_iter(self, pattern):
         return []
 
@@ -125,3 +134,23 @@ def test_dispatch_loop_routes_low_bw(monkeypatch):
     stream, mapping = fake.streams[0]
     assert stream == orchestrator_agent.LOW_BW_JOB_STREAM
     assert fake.jobs[f"job:{mapping['job_id']}"]['batch_id'] == '1'
+
+
+def test_dispatch_priority(monkeypatch):
+    fake = FakeRedis()
+    fake.queue.append('2')
+    fake.store['batch:2'] = {'hashes': '["p"]', 'mask': '?d?d', 'priority': 5}
+    fake.prio['2'] = 5
+    monkeypatch.setattr(orchestrator_agent, 'r', fake)
+    monkeypatch.setattr(redis_manager, 'r', fake)
+    monkeypatch.setattr(orchestrator_agent, 'compute_backlog_target', lambda: 1)
+    monkeypatch.setattr(orchestrator_agent, 'pending_count', lambda *a, **k: 0)
+    monkeypatch.setattr(orchestrator_agent, 'any_darkling_workers', lambda: False)
+    monkeypatch.setattr(orchestrator_agent, 'cache_wordlist', lambda p: '')
+    monkeypatch.setattr(orchestrator_agent, 'average_benchmark_rate', lambda: 0.0)
+    monkeypatch.setattr(orchestrator_agent, 'estimate_keyspace', lambda m, c: 0)
+    monkeypatch.setattr(orchestrator_agent, 'compute_batch_range', lambda r, k: (0, 100))
+    run_once()
+    assert fake.streams
+    stream, mapping = fake.streams[0]
+    assert fake.jobs[f"job:{mapping['job_id']}"]['batch_id'] == '2'

--- a/tests/test_llm_orchestrator.py
+++ b/tests/test_llm_orchestrator.py
@@ -32,6 +32,7 @@ class FakeRedis:
         self.jobs = {}
         self.streams = []
         self.lists = {}
+        self.prio = {}
 
     def rpop(self, name):
         return self.queue.pop(0) if self.queue else None
@@ -55,6 +56,16 @@ class FakeRedis:
         lst = self.lists.get(name, [])
         while value in lst:
             lst.remove(value)
+
+    def zadd(self, name, mapping):
+        self.prio.update(mapping)
+
+    def zrevrange(self, name, start, end):
+        ordered = sorted(self.prio.items(), key=lambda x: -x[1])
+        return [k for k, _ in ordered[start:end+1]]
+
+    def zrem(self, name, member):
+        self.prio.pop(member, None)
 
     def scan_iter(self, pattern):
         return []

--- a/tests/test_orchestrator_agent.py
+++ b/tests/test_orchestrator_agent.py
@@ -18,6 +18,7 @@ class FakeRedis:
         self.raise_err = raise_err
         self.group_created = False
         self.lists = {}
+        self.prio = {}
 
     def xpending(self, stream, group):
         if self.raise_err:
@@ -34,6 +35,16 @@ class FakeRedis:
         lst = self.lists.get(name, [])
         while value in lst:
             lst.remove(value)
+
+    def zadd(self, name, mapping):
+        self.prio.update(mapping)
+
+    def zrevrange(self, name, start, end):
+        ordered = sorted(self.prio.items(), key=lambda x: -x[1])
+        return [k for k, _ in ordered[start:end+1]]
+
+    def zrem(self, name, member):
+        self.prio.pop(member, None)
 
 
 def test_compute_backlog_target(monkeypatch):

--- a/tests/test_process_hashes_jobs.py
+++ b/tests/test_process_hashes_jobs.py
@@ -60,6 +60,7 @@ class FakeRedis:
         self.queue = []
         self.lists = []
         self.sets = {}
+        self.prio = {}
 
     def hset(self, key, mapping=None, **kwargs):
         self.store.setdefault(key, {}).update(mapping or {})
@@ -81,6 +82,16 @@ class FakeRedis:
 
     def lrem(self, name, count, value):
         pass
+
+    def zadd(self, name, mapping):
+        self.prio.update(mapping)
+
+    def zrevrange(self, name, start, end):
+        ordered = sorted(self.prio.items(), key=lambda x: -x[1])
+        return [k for k, _ in ordered[start:end+1]]
+
+    def zrem(self, name, member):
+        self.prio.pop(member, None)
 
     def hget(self, key, field):
         return self.store.get(key, {}).get(field)

--- a/tests/test_redis_manager.py
+++ b/tests/test_redis_manager.py
@@ -14,6 +14,7 @@ class FakeRedis:
     def __init__(self):
         self.store = {}
         self.queue = []
+        self.prio = {}
 
     def sadd(self, key, value):
         self.store.setdefault(key, set()).add(value)
@@ -40,6 +41,16 @@ class FakeRedis:
 
     def rpop(self, name):
         return self.queue.pop() if self.queue else None
+
+    def zadd(self, name, mapping):
+        self.prio.update(mapping)
+
+    def zrevrange(self, name, start, end):
+        ordered = sorted(self.prio.items(), key=lambda x: -x[1])
+        return [k for k, _ in ordered[start:end+1]]
+
+    def zrem(self, name, member):
+        self.prio.pop(member, None)
 
     def hgetall(self, key):
         return dict(self.store.get(key, {}))


### PR DESCRIPTION
## Summary
- support optional priority in `redis_manager.store_batch`
- respect job priority when processing hashes.com jobs
- dispatch priority batches first
- allow setting job priority via `/hashes_job_priority`
- test dispatch order with priority

## Testing
- `pytest -q tests/test_dispatch_loop.py::test_dispatch_priority tests/test_redis_manager.py::test_store_and_get_batch tests/test_process_hashes_jobs.py::test_process_hashes_jobs -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883b17c38148326b33541d7328c64b4