### PR TITLE
Add predefined mask batches

### DIFF
--- a/Server/portal.html
+++ b/Server/portal.html
@@ -141,6 +141,7 @@ body::before {
 <h2>Hashes.com Settings</h2>
 <div>API Key: <input type="password" id="hashes-key"><button onclick="saveHashesKey()">Save</button></div>
 <div>Algorithms: <input type="text" id="hashes-algos"><button onclick="saveHashesAlgos()">Save</button></div>
+<div>Masks: <input type="text" id="predef-masks"><button onclick="savePredefMasks()">Save</button></div>
 </section>
 
 <section id="hashes-jobs">
@@ -380,6 +381,18 @@ async function saveHashesAlgos(){
   await fetch('/hashes_algorithms',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({algorithms:algos})});
 }
 
+async function savePredefMasks(){
+  const txt=document.getElementById('predef-masks').value.trim();
+  const masks=txt?txt.split(',').map(m=>m.trim()).filter(m=>m):[];
+  await fetch('/predefined_masks',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({masks})});
+}
+
+async function loadPredefMasks(){
+  const res=await fetch('/predefined_masks');
+  const data=await res.json();
+  document.getElementById('predef-masks').value=data.join(', ');
+}
+
 async function loadHashesJobs(){
   const res=await fetch('/hashes_jobs');
   const jobs=await res.json();
@@ -425,6 +438,7 @@ function tick(){
   loadJobs();
   loadLogs();
   loadHashesJobs();
+  loadPredefMasks();
 }
 
 function startWS(){

--- a/tests/test_predefined_masks.py
+++ b/tests/test_predefined_masks.py
@@ -1,0 +1,67 @@
+import asyncio
+import sys
+import os
+import types
+
+# Stub FastAPI and Pydantic like other server tests
+fastapi_stub = types.ModuleType('fastapi')
+class FakeApp:
+    def add_middleware(self, *a, **kw):
+        pass
+    def on_event(self, *a, **kw):
+        return lambda f: f
+    def post(self, *a, **kw):
+        return lambda f: f
+    def get(self, *a, **kw):
+        return lambda f: f
+    def delete(self, *a, **kw):
+        return lambda f: f
+    def websocket(self, *a, **kw):
+        return lambda f: f
+fastapi_stub.FastAPI = lambda: FakeApp()
+fastapi_stub.UploadFile = object
+fastapi_stub.File = lambda *a, **kw: None
+fastapi_stub.WebSocket = object
+fastapi_stub.WebSocketDisconnect = type('WebSocketDisconnect', (), {})
+class HTTPException(Exception):
+    pass
+fastapi_stub.HTTPException = HTTPException
+sys.modules.setdefault('fastapi', fastapi_stub)
+
+cors_stub = types.ModuleType('fastapi.middleware.cors')
+cors_stub.CORSMiddleware = object
+sys.modules.setdefault('fastapi.middleware.cors', cors_stub)
+
+resp_stub = types.ModuleType('fastapi.responses')
+resp_stub.HTMLResponse = object
+resp_stub.FileResponse = object
+sys.modules.setdefault('fastapi.responses', resp_stub)
+
+pydantic_stub = types.ModuleType('pydantic')
+class BaseModel:
+    pass
+pydantic_stub.BaseModel = BaseModel
+sys.modules.setdefault('pydantic', pydantic_stub)
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), 'Server'))
+
+import main
+
+
+def test_update_predefined_masks(monkeypatch):
+    monkeypatch.setattr(main, 'CONFIG', {})
+    saved = {}
+    monkeypatch.setattr(main, 'save_config', lambda: saved.setdefault('done', True))
+    req = type('Req', (), {'masks': ['?d?d', '?l?l']})
+    resp = asyncio.run(main.set_predefined_masks(req()))
+    assert resp['status'] == 'ok'
+    assert main.CONFIG['predefined_masks'] == ['?d?d', '?l?l']
+    assert main.PREDEFINED_MASKS == ['?d?d', '?l?l']
+    assert saved.get('done')
+    masks = asyncio.run(main.get_predefined_masks())
+    assert masks == ['?d?d', '?l?l']
+    resp = asyncio.run(main.clear_predefined_masks())
+    assert resp['status'] == 'ok'
+    assert main.CONFIG['predefined_masks'] == []
+    assert main.PREDEFINED_MASKS == []


### PR DESCRIPTION
## Summary
- support configurable `predefined_masks` in server config
- generate batches for predefined masks when processing Hashes.com jobs
- expose `/predefined_masks` API for managing mask list
- display and edit mask list in `portal.html`
- add unit tests for the new API and batch generation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883b9e438dc832691e005634847b34e