### PR TITLE
Add hashes settings endpoint and poll interval

### DIFF
--- a/Server/portal.html
+++ b/Server/portal.html
@@ -141,6 +141,7 @@ body::before {
 <h2>Hashes.com Settings</h2>
 <div>API Key: <input type="password" id="hashes-key"><button onclick="saveHashesKey()">Save</button></div>
 <div>Algorithms: <input type="text" id="hashes-algos"><button onclick="saveHashesAlgos()">Save</button></div>
+<div>Poll Interval: <input type="number" id="hashes-poll" value="0"><button onclick="saveHashesPoll()">Save</button></div>
 <div>Masks: <input type="text" id="predef-masks"><button onclick="savePredefMasks()">Save</button></div>
 </section>
 
@@ -393,6 +394,11 @@ async function saveHashesAlgos(){
   await fetch('/hashes_algorithms',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({algorithms:algos})});
 }
 
+async function saveHashesPoll(){
+  const interval=parseInt(document.getElementById('hashes-poll').value,10)||0;
+  await fetch('/hashes_settings',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({hashes_poll_interval:interval})});
+}
+
 async function savePredefMasks(){
   const txt=document.getElementById('predef-masks').value.trim();
   const masks=txt?txt.split(',').map(m=>m.trim()).filter(m=>m):[];
@@ -434,9 +440,12 @@ async function loadHashesJobs(){
 }
 
 async function loadAlgoParams(){
-  const res=await fetch('/hashes_algo_params');
+  const res=await fetch('/hashes_settings');
   const data=await res.json();
-  document.getElementById('algo-params-output').textContent=JSON.stringify(data,null,2);
+  if(data.hashes_poll_interval!==undefined){
+    document.getElementById('hashes-poll').value=data.hashes_poll_interval;
+  }
+  document.getElementById('algo-params-output').textContent=JSON.stringify(data.algo_params||{},null,2);
 }
 
 async function saveAlgoParams(){
@@ -447,7 +456,9 @@ async function saveAlgoParams(){
   const params={};
   if(mask_length) params.mask_length=mask_length;
   if(rule) params.rule=rule;
-  await fetch('/hashes_algo_params',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({algo,params})});
+  const body={algo_params:{}};
+  body.algo_params[algo.toLowerCase()]=params;
+  await fetch('/hashes_settings',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)});
   loadAlgoParams();
 }
 

--- a/tests/test_hashes_settings.py
+++ b/tests/test_hashes_settings.py
@@ -1,0 +1,90 @@
+import asyncio
+import sys
+import os
+import types
+import pytest
+
+# Minimal FastAPI and Pydantic stubs
+fastapi_stub = types.ModuleType('fastapi')
+class FakeApp:
+    def add_middleware(self, *a, **kw):
+        pass
+    def on_event(self, *a, **kw):
+        return lambda f: f
+    def post(self, *a, **kw):
+        return lambda f: f
+    def get(self, *a, **kw):
+        return lambda f: f
+    def delete(self, *a, **kw):
+        return lambda f: f
+    def websocket(self, *a, **kw):
+        return lambda f: f
+fastapi_stub.FastAPI = lambda: FakeApp()
+fastapi_stub.UploadFile = object
+fastapi_stub.File = lambda *a, **kw: None
+fastapi_stub.WebSocket = object
+fastapi_stub.WebSocketDisconnect = type('WebSocketDisconnect', (), {})
+class HTTPException(Exception):
+    pass
+fastapi_stub.HTTPException = HTTPException
+sys.modules.setdefault('fastapi', fastapi_stub)
+
+cors_stub = types.ModuleType('fastapi.middleware.cors')
+cors_stub.CORSMiddleware = object
+sys.modules.setdefault('fastapi.middleware.cors', cors_stub)
+
+resp_stub = types.ModuleType('fastapi.responses')
+resp_stub.HTMLResponse = object
+resp_stub.FileResponse = object
+sys.modules.setdefault('fastapi.responses', resp_stub)
+
+pydantic_stub = types.ModuleType('pydantic')
+class BaseModel:
+    pass
+pydantic_stub.BaseModel = BaseModel
+sys.modules.setdefault('pydantic', pydantic_stub)
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), 'Server'))
+
+import main
+
+
+@pytest.mark.asyncio
+async def test_set_hashes_settings(monkeypatch):
+    monkeypatch.setattr(main, 'CONFIG', {})
+    monkeypatch.setattr(main, 'HASHES_SETTINGS', {})
+    monkeypatch.setattr(main, 'HASHES_POLL_INTERVAL', 1800)
+    monkeypatch.setattr(main, 'HASHES_ALGO_PARAMS', {})
+    saved = {}
+    monkeypatch.setattr(main, 'save_config', lambda: saved.setdefault('done', True))
+    req = type('Req', (), {
+        'hashes_poll_interval': 60,
+        'algo_params': {'md5': {'mask_length': 8}}
+    })
+    resp = await main.set_hashes_settings(req())
+    assert resp['status'] == 'ok'
+    assert main.CONFIG['hashes_settings']['hashes_poll_interval'] == 60
+    assert main.HASHES_SETTINGS['hashes_poll_interval'] == 60
+    assert main.HASHES_ALGO_PARAMS['md5'] == {'mask_length': 8}
+    assert saved.get('done')
+    settings = await main.get_hashes_settings()
+    assert settings['hashes_poll_interval'] == 60
+
+
+@pytest.mark.asyncio
+async def test_poll_hashes_jobs_uses_setting(monkeypatch):
+    monkeypatch.setattr(main, 'HASHES_SETTINGS', {'hashes_poll_interval': 5})
+    called = {}
+    async def fake_fetch():
+        called['fetch'] = True
+    monkeypatch.setattr(main, 'fetch_and_store_jobs', fake_fetch)
+
+    async def fake_sleep(t):
+        called['sleep'] = t
+        raise StopAsyncIteration
+    monkeypatch.setattr(asyncio, 'sleep', fake_sleep)
+    with pytest.raises(StopAsyncIteration):
+        await main.poll_hashes_jobs()
+    assert called.get('sleep') == 5
+


### PR DESCRIPTION
## Summary
- provide HASHES_SETTINGS dictionary and `/hashes_settings` API
- allow `poll_hashes_jobs` to read poll interval dynamically
- update portal to edit poll interval and algorithm parameters
- test hashes settings persistence and poll interval usage

## Testing
- `pip install -q -r Server/requirements.txt`
- `pip install -q -r Server/requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883c3c4cbf883269f280f30c14ef55d