### PR TITLE
Add inverse probabilistic ordering support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ also supply `--server-ip` to skip auto-discovery. After setup, run
 Both components generate their RSA signing keys automatically the first time
 they run if no key files are present.
 
+Workers can enable probabilistic candidate ordering using `--probabilistic-order`.
+Use `--inverse-prob-order` to iterate from least likely candidates first. The
+server portal exposes matching checkboxes under the Markov Training section.
+
 ## Thread Safety
 
 Both the server and worker load their private signing keys once at module import

--- a/Server/main.py
+++ b/Server/main.py
@@ -140,6 +140,7 @@ HASHES_ALGO_PARAMS: dict[str, dict[str, Any]] = dict(
 
 # Markov and candidate ordering settings
 PROBABILISTIC_ORDER = bool(CONFIG.get("probabilistic_order", False))
+INVERSE_PROB_ORDER = bool(CONFIG.get("inverse_prob_order", False))
 MARKOV_LANG = CONFIG.get("markov_lang", "english")
 
 # local language model settings
@@ -165,6 +166,7 @@ def save_config():
         CONFIG["llm_model_path"] = LLM_MODEL_PATH
         CONFIG["llm_train_epochs"] = int(LLM_TRAIN_EPOCHS)
         CONFIG["llm_train_learning_rate"] = float(LLM_TRAIN_LEARNING_RATE)
+        CONFIG["inverse_prob_order"] = bool(INVERSE_PROB_ORDER)
 
         with open(CONFIG_FILE, "w") as f:
             json.dump(CONFIG, f, indent=2)
@@ -835,6 +837,7 @@ async def server_status():
             "gpu_temps": get_gpu_temps(),
             "low_bw_engine": LOW_BW_ENGINE,
             "probabilistic_order": PROBABILISTIC_ORDER,
+            "inverse_prob_order": INVERSE_PROB_ORDER,
             "markov_lang": MARKOV_LANG,
             "llm_train_epochs": LLM_TRAIN_EPOCHS,
             "llm_train_learning_rate": LLM_TRAIN_LEARNING_RATE,
@@ -1630,6 +1633,20 @@ async def set_probabilistic_order(req: ProbOrderRequest):
     CONFIG["probabilistic_order"] = bool(req.enabled)
     global PROBABILISTIC_ORDER
     PROBABILISTIC_ORDER = bool(req.enabled)
+    save_config()
+    return {"status": "ok"}
+
+
+class InverseOrderRequest(BaseModel):
+    enabled: bool
+
+
+@app.post("/inverse_prob_order")
+async def set_inverse_prob_order(req: InverseOrderRequest):
+    """Enable or disable inverse probabilistic ordering."""
+    CONFIG["inverse_prob_order"] = bool(req.enabled)
+    global INVERSE_PROB_ORDER
+    INVERSE_PROB_ORDER = bool(req.enabled)
     save_config()
     return {"status": "ok"}
 

--- a/Server/portal.html
+++ b/Server/portal.html
@@ -178,8 +178,12 @@ body::before {
 <div>
   <label><input type="checkbox" id="prob-order" onchange="updateProbOrder()"> Probabilistic Ordering</label>
 </div>
+<div>
+  <label><input type="checkbox" id="inverse-order" onchange="updateInverseOrder()"> Inverse Order</label>
+</div>
 <div>Current Language: <span id="current-markov-lang"></span></div>
   <div>Probabilistic Order: <span id="current-prob-order"></span></div>
+  <div>Inverse Order: <span id="current-inverse-order"></span></div>
 </section>
 
 <section id="llm-training">
@@ -202,8 +206,10 @@ function applyMetrics(data){
   document.getElementById('gpu').textContent = (data.gpu_temps || []).join(',');
   document.getElementById('updated').textContent = 'Updated: ' + new Date().toLocaleTimeString();
   document.getElementById('current-prob-order').textContent = data.probabilistic_order ? 'on' : 'off';
+  document.getElementById('current-inverse-order').textContent = data.inverse_prob_order ? 'on' : 'off';
   document.getElementById('current-markov-lang').textContent = data.markov_lang || '';
   document.getElementById('prob-order').checked = !!data.probabilistic_order;
+  document.getElementById('inverse-order').checked = !!data.inverse_prob_order;
   document.getElementById('markov-language').value = data.markov_lang || 'english';
   if(data.llm_train_epochs!==undefined){
     document.getElementById('llm-epochs').value = data.llm_train_epochs;
@@ -470,6 +476,12 @@ async function trainMarkov(){
 async function updateProbOrder(){
   const enabled=document.getElementById('prob-order').checked;
   await fetch('/probabilistic_order',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({enabled})});
+  updateMetrics();
+}
+
+async function updateInverseOrder(){
+  const enabled=document.getElementById('inverse-order').checked;
+  await fetch('/inverse_prob_order',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({enabled})});
   updateMetrics();
 }
 

--- a/Worker/hashmancer_worker/gpu_sidecar.py
+++ b/Worker/hashmancer_worker/gpu_sidecar.py
@@ -85,6 +85,7 @@ class GPUSidecar(threading.Thread):
         server_url: str,
         probabilistic_order: bool = False,
         markov_lang: str = "english",
+        inverse_order: bool = False,
     ):
         super().__init__(daemon=True)
         self.worker_id = worker_id
@@ -92,6 +93,7 @@ class GPUSidecar(threading.Thread):
         self.server_url = server_url
         self.probabilistic_order = probabilistic_order
         self.markov_lang = markov_lang
+        self.inverse_order = inverse_order
         self.running = True
         self.current_job = None
         self.hashrate = 0.0
@@ -454,7 +456,7 @@ class GPUSidecar(threading.Thread):
         if self.probabilistic_order:
             markov = statistics.load_markov(lang=self.markov_lang)
             indices = statistics.probability_index_order(
-                batch.get("mask", ""), cs_map, markov
+                batch.get("mask", ""), cs_map, markov, inverse=self.inverse_order
             )
 
         for chunk in hash_chunks:

--- a/Worker/hashmancer_worker/worker_agent.py
+++ b/Worker/hashmancer_worker/worker_agent.py
@@ -275,10 +275,16 @@ def main(argv: list[str] | None = None):
         action="store_true",
         help="use Markov tables for probabilistic candidate ordering",
     )
+    parser.add_argument(
+        "--inverse-prob-order",
+        action="store_true",
+        help="iterate candidates from least likely first",
+    )
     args = parser.parse_args(argv)
 
     probabilistic_order = False
     markov_lang = "english"
+    inverse_prob_order = False
 
     print_logo()
     worker_id = os.getenv("WORKER_ID", str(uuid.uuid4()))
@@ -294,9 +300,14 @@ def main(argv: list[str] | None = None):
             probabilistic_order = data.get("probabilistic_order", False)
         else:
             probabilistic_order = True
+        if not args.inverse_prob_order:
+            inverse_prob_order = data.get("inverse_prob_order", False)
+        else:
+            inverse_prob_order = True
         markov_lang = data.get("markov_lang", "english")
     except Exception:
         probabilistic_order = args.probabilistic_order
+        inverse_prob_order = args.inverse_prob_order
         pass
 
     for gpu in gpus:
@@ -333,6 +344,7 @@ def main(argv: list[str] | None = None):
                     SERVER_URL,
                     probabilistic_order=probabilistic_order,
                     markov_lang=markov_lang,
+                    inverse_order=inverse_prob_order,
                 )
             )
         except TypeError:
@@ -343,6 +355,7 @@ def main(argv: list[str] | None = None):
                     SERVER_URL,
                     probabilistic_order=probabilistic_order,
                     markov_lang=markov_lang,
+                    inverse_order=inverse_prob_order,
                 )
             )
     for t in threads:

--- a/darkling/statistics.py
+++ b/darkling/statistics.py
@@ -62,18 +62,25 @@ def _digits_to_index(digits: List[int], bases: List[int]) -> int:
     return idx
 
 
-def _sorted_indices(charset: str, probs: Dict[str, int]) -> List[int]:
+def _sorted_indices(charset: str, probs: Dict[str, int], *, reverse: bool = True) -> List[int]:
     groups: Dict[str, List[int]] = defaultdict(list)
     for i, ch in enumerate(charset):
         groups[_char_token(ch)].append(i)
-    tokens = sorted(groups, key=lambda t: probs.get(t, 0), reverse=True)
+    tokens = sorted(groups, key=lambda t: probs.get(t, 0), reverse=reverse)
     order: List[int] = []
     for t in tokens:
         order.extend(groups[t])
     return order
 
 
-def probability_index_order(mask: str, charset_map: Dict[str, str], markov: dict, limit: int | None = None) -> List[int]:
+def probability_index_order(
+    mask: str,
+    charset_map: Dict[str, str],
+    markov: dict,
+    limit: int | None = None,
+    *,
+    inverse: bool = False,
+) -> List[int]:
     """Return candidate indices for *mask* sorted by Markov probability."""
     charsets_list: List[str] = []
     i = 0
@@ -101,7 +108,7 @@ def probability_index_order(mask: str, charset_map: Dict[str, str], markov: dict
             return
         charset = charsets_list[pos]
         probs = start_probs if pos == 0 else trans[pos - 1].get(prev, start_probs)
-        for idx in _sorted_indices(charset, probs):
+        for idx in _sorted_indices(charset, probs, reverse=not inverse):
             digits[pos] = idx
             token = _char_token(charset[idx]) if charset else prev
             recurse(pos + 1, token)

--- a/tests/test_server_markov.py
+++ b/tests/test_server_markov.py
@@ -105,6 +105,18 @@ def test_update_probabilistic_order(monkeypatch):
     assert saved.get('done')
 
 
+def test_update_inverse_prob_order(monkeypatch):
+    monkeypatch.setattr(main, 'CONFIG', {})
+    saved = {}
+    monkeypatch.setattr(main, 'save_config', lambda: saved.setdefault('done', True))
+    req = type('Req', (), {'enabled': True})
+    resp = asyncio.run(main.set_inverse_prob_order(req()))
+    assert resp['status'] == 'ok'
+    assert main.CONFIG['inverse_prob_order'] is True
+    assert main.INVERSE_PROB_ORDER is True
+    assert saved.get('done')
+
+
 def test_update_markov_lang(monkeypatch):
     monkeypatch.setattr(main, 'CONFIG', {})
     saved = {}
@@ -121,6 +133,7 @@ def test_server_status_includes_settings(monkeypatch):
     fake = DummyRedis()
     monkeypatch.setattr(main, 'r', fake)
     monkeypatch.setattr(main, 'PROBABILISTIC_ORDER', True)
+    monkeypatch.setattr(main, 'INVERSE_PROB_ORDER', True)
     monkeypatch.setattr(main, 'MARKOV_LANG', 'spanish')
     monkeypatch.setattr(main, 'LLM_TRAIN_EPOCHS', 2)
     monkeypatch.setattr(main, 'LLM_TRAIN_LEARNING_RATE', 0.002)
@@ -128,6 +141,7 @@ def test_server_status_includes_settings(monkeypatch):
     monkeypatch.setattr(main.orchestrator_agent, 'pending_count', lambda: 2)
     status = asyncio.run(main.server_status())
     assert status['probabilistic_order'] is True
+    assert status['inverse_prob_order'] is True
     assert status['markov_lang'] == 'spanish'
     assert status['llm_train_epochs'] == 2
     assert status['llm_train_learning_rate'] == 0.002

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -16,3 +16,13 @@ def test_probability_order_indices():
     order = statistics.probability_index_order("?1?2", charset_map, markov)
     assert order[:4] == [1, 0, 2, 3]
 
+
+def test_probability_order_inverse():
+    records = [("$U$l", 3), ("$U$U", 1)]
+    markov = statistics.build_markov(records)
+    charset_map = {"?1": "Ac", "?2": "Xy"}
+    order = statistics.probability_index_order(
+        "?1?2", charset_map, markov, inverse=True
+    )
+    assert order[:4] == [3, 2, 0, 1]
+

--- a/tests/test_worker_agent.py
+++ b/tests/test_worker_agent.py
@@ -149,7 +149,13 @@ def test_benchmark_low_bw_gpu(monkeypatch):
 
     class DummySidecar:
         def __init__(
-            self, name, gpu, url, probabilistic_order=False, markov_lang="english"
+            self,
+            name,
+            gpu,
+            url,
+            probabilistic_order=False,
+            markov_lang="english",
+            inverse_order=False,
         ):
             self.gpu = gpu
             self.progress = 0.0
@@ -208,6 +214,7 @@ def test_prob_order_from_server(monkeypatch):
                 "low_bw_engine": "hashcat",
                 "probabilistic_order": True,
                 "markov_lang": "spanish",
+                "inverse_prob_order": True,
             }
         ),
     )
@@ -225,10 +232,17 @@ def test_prob_order_from_server(monkeypatch):
 
     class DummySidecar:
         def __init__(
-            self, name, gpu, url, probabilistic_order=False, markov_lang="english"
+            self,
+            name,
+            gpu,
+            url,
+            probabilistic_order=False,
+            markov_lang="english",
+            inverse_order=False,
         ):
             captured["prob"] = probabilistic_order
             captured["lang"] = markov_lang
+            captured["inv"] = inverse_order
             self.gpu = gpu
             self.progress = 0.0
             self.current_job = None
@@ -268,3 +282,4 @@ def test_prob_order_from_server(monkeypatch):
 
     assert captured["prob"] is True
     assert captured["lang"] == "spanish"
+    assert captured["inv"] is True


### PR DESCRIPTION
## Summary
- support ascending Markov ordering
- add `inverse_order` option to GPU sidecar and wire through worker
- expose `/inverse_prob_order` endpoint and UI toggle
- update server status and README
- test probability order inversion, server API, and worker usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883dba17580832688ed1dde385a5ad4