### PR TITLE
Refactor test stubs

### DIFF
--- a/tests/test_allowed_origins.py
+++ b/tests/test_allowed_origins.py
@@ -1,3 +1,5 @@
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import os
 import sys
 import json
@@ -11,61 +13,16 @@ psutil_stub.disk_usage = lambda path: types.SimpleNamespace(percent=0.0)
 psutil_stub.getloadavg = lambda: (0.0, 0.0, 0.0)
 sys.modules.setdefault("psutil", psutil_stub)
 
-fastapi_stub = types.ModuleType("fastapi")
+from tests.test_helpers import (
+    fastapi_stub,
+    cors_stub,
+    resp_stub,
+    pydantic_stub,
+    install_stubs,
+    FakeApp,
+)
 
-class FakeApp:
-    def __init__(self):
-        self.added = []
-
-    def add_middleware(self, *a, **kw):
-        self.added.append((a, kw))
-
-    def on_event(self, *a, **kw):
-        return lambda f: f
-
-    def post(self, *a, **kw):
-        return lambda f: f
-
-    def get(self, *a, **kw):
-        return lambda f: f
-
-    def delete(self, *a, **kw):
-        return lambda f: f
-
-    def websocket(self, *a, **kw):
-        return lambda f: f
-
-fastapi_stub.FastAPI = lambda: FakeApp()
-fastapi_stub.UploadFile = object
-fastapi_stub.File = lambda *a, **kw: None
-fastapi_stub.WebSocket = object
-fastapi_stub.WebSocketDisconnect = type("WebSocketDisconnect", (Exception,), {})
-
-class HTTPException(Exception):
-    pass
-fastapi_stub.HTTPException = HTTPException
-
-pydantic_stub = types.ModuleType("pydantic")
-class BaseModel:
-    pass
-pydantic_stub.BaseModel = BaseModel
-
-cors_stub = types.ModuleType("fastapi.middleware.cors")
-cors_stub.CORSMiddleware = type("CORSMiddleware", (), {})
-
-resp_stub = types.ModuleType("fastapi.responses")
-class DummyHTMLResponse:
-    def __init__(self, text, status_code=200):
-        self.text = text
-        self.status_code = status_code
-        self.called = False
-
-    async def __call__(self, scope, receive, send):
-        self.called = True
-        await send({"status": self.status_code, "body": self.text})
-
-resp_stub.HTMLResponse = DummyHTMLResponse
-resp_stub.FileResponse = object
+install_stubs()
 
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))

--- a/tests/test_auth_middleware.py
+++ b/tests/test_auth_middleware.py
@@ -1,78 +1,21 @@
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import asyncio
 import json
 import sys
 import os
-import types
 import pytest
 
-# Stub FastAPI and related pieces similar to other tests
-fastapi_stub = types.ModuleType("fastapi")
+from tests.test_helpers import (
+    fastapi_stub,
+    cors_stub,
+    resp_stub,
+    pydantic_stub,
+    install_stubs,
+    FakeApp,
+)
 
-class FakeApp:
-    def __init__(self):
-        self.called = False
-
-    async def __call__(self, scope, receive, send):
-        self.called = True
-        await send({"done": True})
-
-    def add_middleware(self, *a, **kw):
-        pass
-
-    def on_event(self, *a, **kw):
-        return lambda f: f
-
-    def post(self, *a, **kw):
-        return lambda f: f
-
-    def get(self, *a, **kw):
-        return lambda f: f
-
-    def delete(self, *a, **kw):
-        return lambda f: f
-
-    def websocket(self, *a, **kw):
-        return lambda f: f
-
-fastapi_stub.FastAPI = lambda: FakeApp()
-fastapi_stub.UploadFile = object
-fastapi_stub.File = lambda *a, **kw: None
-fastapi_stub.WebSocket = object
-fastapi_stub.WebSocketDisconnect = type("WebSocketDisconnect", (Exception,), {})
-
-class HTTPException(Exception):
-    pass
-
-fastapi_stub.HTTPException = HTTPException
-sys.modules.setdefault("fastapi", fastapi_stub)
-
-cors_stub = types.ModuleType("fastapi.middleware.cors")
-cors_stub.CORSMiddleware = object
-sys.modules.setdefault("fastapi.middleware.cors", cors_stub)
-
-resp_stub = types.ModuleType("fastapi.responses")
-
-class DummyHTMLResponse:
-    def __init__(self, text, status_code=200):
-        self.text = text
-        self.status_code = status_code
-        self.called = False
-
-    async def __call__(self, scope, receive, send):
-        self.called = True
-        await send({"status": self.status_code, "body": self.text})
-
-resp_stub.HTMLResponse = DummyHTMLResponse
-resp_stub.FileResponse = object
-sys.modules.setdefault("fastapi.responses", resp_stub)
-
-pydantic_stub = types.ModuleType("pydantic")
-
-class BaseModel:
-    pass
-
-pydantic_stub.BaseModel = BaseModel
-sys.modules.setdefault("pydantic", pydantic_stub)
+install_stubs()
 
 
 

--- a/tests/test_dispatch_loop.py
+++ b/tests/test_dispatch_loop.py
@@ -1,47 +1,19 @@
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import asyncio
 import sys
 import os
-import types
 
-# Stub FastAPI and related heavy modules
-fastapi_stub = types.ModuleType('fastapi')
-class FakeApp:
-    def add_middleware(self, *a, **kw):
-        pass
-    def on_event(self, *a, **kw):
-        return lambda f: f
-    def post(self, *a, **kw):
-        return lambda f: f
-    def get(self, *a, **kw):
-        return lambda f: f
-    def delete(self, *a, **kw):
-        return lambda f: f
-    def websocket(self, *a, **kw):
-        return lambda f: f
-fastapi_stub.FastAPI = lambda: FakeApp()
-fastapi_stub.UploadFile = object
-fastapi_stub.File = lambda *a, **kw: None
-fastapi_stub.WebSocket = object
-fastapi_stub.WebSocketDisconnect = type('WebSocketDisconnect', (), {})
-class HTTPException(Exception):
-    pass
-fastapi_stub.HTTPException = HTTPException
-sys.modules.setdefault('fastapi', fastapi_stub)
+from tests.test_helpers import (
+    fastapi_stub,
+    cors_stub,
+    resp_stub,
+    pydantic_stub,
+    install_stubs,
+    FakeApp,
+)
 
-cors_stub = types.ModuleType('fastapi.middleware.cors')
-cors_stub.CORSMiddleware = object
-sys.modules.setdefault('fastapi.middleware.cors', cors_stub)
-
-resp_stub = types.ModuleType('fastapi.responses')
-resp_stub.HTMLResponse = object
-resp_stub.FileResponse = object
-sys.modules.setdefault('fastapi.responses', resp_stub)
-
-pydantic_stub = types.ModuleType('pydantic')
-class BaseModel:
-    pass
-pydantic_stub.BaseModel = BaseModel
-sys.modules.setdefault('pydantic', pydantic_stub)
+install_stubs()
 
 
 # Add repo paths

--- a/tests/test_flash_queue.py
+++ b/tests/test_flash_queue.py
@@ -1,63 +1,19 @@
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import asyncio
 import sys
 import os
-import types
 
-# Stub modules similar to other server tests
-fastapi_stub = types.ModuleType("fastapi")
+from tests.test_helpers import (
+    fastapi_stub,
+    cors_stub,
+    resp_stub,
+    pydantic_stub,
+    install_stubs,
+    FakeApp,
+)
 
-
-class FakeApp:
-    def add_middleware(self, *a, **kw):
-        pass
-
-    def on_event(self, *a, **kw):
-        return lambda f: f
-
-    def post(self, *a, **kw):
-        return lambda f: f
-
-    def get(self, *a, **kw):
-        return lambda f: f
-
-    def delete(self, *a, **kw):
-        return lambda f: f
-
-    def websocket(self, *a, **kw):
-        return lambda f: f
-
-
-fastapi_stub.FastAPI = lambda: FakeApp()
-fastapi_stub.UploadFile = object
-fastapi_stub.File = lambda *a, **kw: None
-fastapi_stub.WebSocket = object
-fastapi_stub.WebSocketDisconnect = type("WebSocketDisconnect", (), {})
-
-
-class HTTPException(Exception):
-    pass
-
-
-fastapi_stub.HTTPException = HTTPException
-sys.modules.setdefault("fastapi", fastapi_stub)
-
-cors_stub = types.ModuleType("fastapi.middleware.cors")
-cors_stub.CORSMiddleware = object
-sys.modules.setdefault("fastapi.middleware.cors", cors_stub)
-
-resp_stub = types.ModuleType("fastapi.responses")
-resp_stub.HTMLResponse = object
-sys.modules.setdefault("fastapi.responses", resp_stub)
-
-pydantic_stub = types.ModuleType("pydantic")
-
-
-class BaseModel:
-    pass
-
-
-pydantic_stub.BaseModel = BaseModel
-sys.modules.setdefault("pydantic", pydantic_stub)
+install_stubs()
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), "Server"))

--- a/tests/test_hash_algos.py
+++ b/tests/test_hash_algos.py
@@ -1,46 +1,19 @@
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import asyncio
 import sys
 import os
-import types
 
-fastapi_stub = types.ModuleType('fastapi')
-class FakeApp:
-    def add_middleware(self, *a, **kw):
-        pass
-    def on_event(self, *a, **kw):
-        return lambda f: f
-    def post(self, *a, **kw):
-        return lambda f: f
-    def get(self, *a, **kw):
-        return lambda f: f
-    def delete(self, *a, **kw):
-        return lambda f: f
-    def websocket(self, *a, **kw):
-        return lambda f: f
-fastapi_stub.FastAPI = lambda: FakeApp()
-fastapi_stub.UploadFile = object
-fastapi_stub.File = lambda *a, **kw: None
-fastapi_stub.WebSocket = object
-fastapi_stub.WebSocketDisconnect = type('WebSocketDisconnect', (), {})
-class HTTPException(Exception):
-    pass
-fastapi_stub.HTTPException = HTTPException
-sys.modules.setdefault('fastapi', fastapi_stub)
+from tests.test_helpers import (
+    fastapi_stub,
+    cors_stub,
+    resp_stub,
+    pydantic_stub,
+    install_stubs,
+    FakeApp,
+)
 
-cors_stub = types.ModuleType('fastapi.middleware.cors')
-cors_stub.CORSMiddleware = object
-sys.modules.setdefault('fastapi.middleware.cors', cors_stub)
-
-resp_stub = types.ModuleType('fastapi.responses')
-resp_stub.HTMLResponse = object
-resp_stub.FileResponse = object
-sys.modules.setdefault('fastapi.responses', resp_stub)
-
-pydantic_stub = types.ModuleType('pydantic')
-class BaseModel:
-    pass
-pydantic_stub.BaseModel = BaseModel
-sys.modules.setdefault('pydantic', pydantic_stub)
+install_stubs()
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), 'Server'))

--- a/tests/test_hashes_config.py
+++ b/tests/test_hashes_config.py
@@ -1,47 +1,19 @@
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import asyncio
 import sys
 import os
-import types
 
-# Stub FastAPI and Pydantic similar to other server tests
-fastapi_stub = types.ModuleType('fastapi')
-class FakeApp:
-    def add_middleware(self, *a, **kw):
-        pass
-    def on_event(self, *a, **kw):
-        return lambda f: f
-    def post(self, *a, **kw):
-        return lambda f: f
-    def get(self, *a, **kw):
-        return lambda f: f
-    def delete(self, *a, **kw):
-        return lambda f: f
-    def websocket(self, *a, **kw):
-        return lambda f: f
-fastapi_stub.FastAPI = lambda: FakeApp()
-fastapi_stub.UploadFile = object
-fastapi_stub.File = lambda *a, **kw: None
-fastapi_stub.WebSocket = object
-fastapi_stub.WebSocketDisconnect = type('WebSocketDisconnect', (), {})
-class HTTPException(Exception):
-    pass
-fastapi_stub.HTTPException = HTTPException
-sys.modules.setdefault('fastapi', fastapi_stub)
+from tests.test_helpers import (
+    fastapi_stub,
+    cors_stub,
+    resp_stub,
+    pydantic_stub,
+    install_stubs,
+    FakeApp,
+)
 
-cors_stub = types.ModuleType('fastapi.middleware.cors')
-cors_stub.CORSMiddleware = object
-sys.modules.setdefault('fastapi.middleware.cors', cors_stub)
-
-resp_stub = types.ModuleType('fastapi.responses')
-resp_stub.HTMLResponse = object
-resp_stub.FileResponse = object
-sys.modules.setdefault('fastapi.responses', resp_stub)
-
-pydantic_stub = types.ModuleType('pydantic')
-class BaseModel:
-    pass
-pydantic_stub.BaseModel = BaseModel
-sys.modules.setdefault('pydantic', pydantic_stub)
+install_stubs()
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), 'Server'))

--- a/tests/test_hashes_poll.py
+++ b/tests/test_hashes_poll.py
@@ -1,44 +1,18 @@
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import asyncio
 import sys
-import types
 
-fastapi_stub = types.ModuleType('fastapi')
-class FakeApp:
-    def add_middleware(self, *a, **kw):
-        pass
-    def on_event(self, *a, **kw):
-        return lambda f: f
-    def post(self, *a, **kw):
-        return lambda f: f
-    def get(self, *a, **kw):
-        return lambda f: f
-    def delete(self, *a, **kw):
-        return lambda f: f
-    def websocket(self, *a, **kw):
-        return lambda f: f
-fastapi_stub.FastAPI = lambda: FakeApp()
-fastapi_stub.UploadFile = object
-fastapi_stub.File = lambda *a, **kw: None
-fastapi_stub.WebSocket = object
-fastapi_stub.WebSocketDisconnect = type('WebSocketDisconnect', (), {})
-class HTTPException(Exception):
-    pass
-fastapi_stub.HTTPException = HTTPException
-sys.modules.setdefault('fastapi', fastapi_stub)
+from tests.test_helpers import (
+    fastapi_stub,
+    cors_stub,
+    resp_stub,
+    pydantic_stub,
+    install_stubs,
+    FakeApp,
+)
 
-cors_stub = types.ModuleType('fastapi.middleware.cors')
-cors_stub.CORSMiddleware = object
-sys.modules.setdefault('fastapi.middleware.cors', cors_stub)
-
-resp_stub = types.ModuleType('fastapi.responses')
-resp_stub.HTMLResponse = object
-sys.modules.setdefault('fastapi.responses', resp_stub)
-
-pydantic_stub = types.ModuleType('pydantic')
-class BaseModel:
-    pass
-pydantic_stub.BaseModel = BaseModel
-sys.modules.setdefault('pydantic', pydantic_stub)
+install_stubs()
 
 
 sys.path.insert(0, '..')

--- a/tests/test_hashes_settings.py
+++ b/tests/test_hashes_settings.py
@@ -1,48 +1,20 @@
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import asyncio
 import sys
 import os
-import types
 import pytest
 
-# Minimal FastAPI and Pydantic stubs
-fastapi_stub = types.ModuleType('fastapi')
-class FakeApp:
-    def add_middleware(self, *a, **kw):
-        pass
-    def on_event(self, *a, **kw):
-        return lambda f: f
-    def post(self, *a, **kw):
-        return lambda f: f
-    def get(self, *a, **kw):
-        return lambda f: f
-    def delete(self, *a, **kw):
-        return lambda f: f
-    def websocket(self, *a, **kw):
-        return lambda f: f
-fastapi_stub.FastAPI = lambda: FakeApp()
-fastapi_stub.UploadFile = object
-fastapi_stub.File = lambda *a, **kw: None
-fastapi_stub.WebSocket = object
-fastapi_stub.WebSocketDisconnect = type('WebSocketDisconnect', (), {})
-class HTTPException(Exception):
-    pass
-fastapi_stub.HTTPException = HTTPException
-sys.modules.setdefault('fastapi', fastapi_stub)
+from tests.test_helpers import (
+    fastapi_stub,
+    cors_stub,
+    resp_stub,
+    pydantic_stub,
+    install_stubs,
+    FakeApp,
+)
 
-cors_stub = types.ModuleType('fastapi.middleware.cors')
-cors_stub.CORSMiddleware = object
-sys.modules.setdefault('fastapi.middleware.cors', cors_stub)
-
-resp_stub = types.ModuleType('fastapi.responses')
-resp_stub.HTMLResponse = object
-resp_stub.FileResponse = object
-sys.modules.setdefault('fastapi.responses', resp_stub)
-
-pydantic_stub = types.ModuleType('pydantic')
-class BaseModel:
-    pass
-pydantic_stub.BaseModel = BaseModel
-sys.modules.setdefault('pydantic', pydantic_stub)
+install_stubs()
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), 'Server'))

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,76 @@
+import sys
+import types
+
+class FakeApp:
+    def __init__(self):
+        self.called = False
+        self.added = []
+
+    async def __call__(self, scope, receive, send):
+        self.called = True
+        await send({"done": True})
+
+    def add_middleware(self, *a, **kw):
+        self.added.append((a, kw))
+
+    def on_event(self, *a, **kw):
+        return lambda f: f
+
+    def post(self, *a, **kw):
+        return lambda f: f
+
+    def get(self, *a, **kw):
+        return lambda f: f
+
+    def delete(self, *a, **kw):
+        return lambda f: f
+
+    def websocket(self, *a, **kw):
+        return lambda f: f
+
+class HTTPException(Exception):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args)
+
+class DummyHTMLResponse:
+    def __init__(self, text, status_code=200):
+        self.text = text
+        self.status_code = status_code
+        self.called = False
+
+    async def __call__(self, scope, receive, send):
+        self.called = True
+        await send({"status": self.status_code, "body": self.text})
+
+class BaseModel:
+    pass
+
+# FastAPI stub
+fastapi_stub = types.ModuleType("fastapi")
+fastapi_stub.FastAPI = lambda: FakeApp()
+fastapi_stub.UploadFile = object
+fastapi_stub.File = lambda *a, **kw: None
+fastapi_stub.WebSocket = object
+fastapi_stub.WebSocketDisconnect = type("WebSocketDisconnect", (Exception,), {})
+fastapi_stub.HTTPException = HTTPException
+
+# CORS stub
+cors_stub = types.ModuleType("fastapi.middleware.cors")
+cors_stub.CORSMiddleware = object
+
+# Response stub
+resp_stub = types.ModuleType("fastapi.responses")
+resp_stub.HTMLResponse = DummyHTMLResponse
+resp_stub.FileResponse = object
+
+# Pydantic stub
+pydantic_stub = types.ModuleType("pydantic")
+pydantic_stub.BaseModel = BaseModel
+
+
+def install_stubs():
+    sys.modules.setdefault("fastapi", fastapi_stub)
+    sys.modules.setdefault("fastapi.middleware.cors", cors_stub)
+    sys.modules.setdefault("fastapi.responses", resp_stub)
+    sys.modules.setdefault("pydantic", pydantic_stub)
+

--- a/tests/test_import_hashes.py
+++ b/tests/test_import_hashes.py
@@ -1,48 +1,20 @@
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import asyncio
 import sys
 import os
-import types
 import json
 
-# Stub modules as in other server tests
-fastapi_stub = types.ModuleType("fastapi")
-class FakeApp:
-    def add_middleware(self, *a, **kw):
-        pass
-    def on_event(self, *a, **kw):
-        return lambda f: f
-    def post(self, *a, **kw):
-        return lambda f: f
-    def get(self, *a, **kw):
-        return lambda f: f
-    def delete(self, *a, **kw):
-        return lambda f: f
-    def websocket(self, *a, **kw):
-        return lambda f: f
-fastapi_stub.FastAPI = lambda: FakeApp()
-fastapi_stub.UploadFile = object
-fastapi_stub.File = lambda *a, **kw: None
-fastapi_stub.WebSocket = object
-fastapi_stub.WebSocketDisconnect = type("WebSocketDisconnect", (), {})
-class HTTPException(Exception):
-    pass
-fastapi_stub.HTTPException = HTTPException
-sys.modules.setdefault("fastapi", fastapi_stub)
+from tests.test_helpers import (
+    fastapi_stub,
+    cors_stub,
+    resp_stub,
+    pydantic_stub,
+    install_stubs,
+    FakeApp,
+)
 
-cors_stub = types.ModuleType("fastapi.middleware.cors")
-cors_stub.CORSMiddleware = object
-sys.modules.setdefault("fastapi.middleware.cors", cors_stub)
-
-resp_stub = types.ModuleType("fastapi.responses")
-resp_stub.HTMLResponse = object
-resp_stub.FileResponse = object
-sys.modules.setdefault("fastapi.responses", resp_stub)
-
-pydantic_stub = types.ModuleType("pydantic")
-class BaseModel:
-    pass
-pydantic_stub.BaseModel = BaseModel
-sys.modules.setdefault("pydantic", pydantic_stub)
+install_stubs()
 
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))

--- a/tests/test_predefined_masks.py
+++ b/tests/test_predefined_masks.py
@@ -1,47 +1,19 @@
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import asyncio
 import sys
 import os
-import types
 
-# Stub FastAPI and Pydantic like other server tests
-fastapi_stub = types.ModuleType('fastapi')
-class FakeApp:
-    def add_middleware(self, *a, **kw):
-        pass
-    def on_event(self, *a, **kw):
-        return lambda f: f
-    def post(self, *a, **kw):
-        return lambda f: f
-    def get(self, *a, **kw):
-        return lambda f: f
-    def delete(self, *a, **kw):
-        return lambda f: f
-    def websocket(self, *a, **kw):
-        return lambda f: f
-fastapi_stub.FastAPI = lambda: FakeApp()
-fastapi_stub.UploadFile = object
-fastapi_stub.File = lambda *a, **kw: None
-fastapi_stub.WebSocket = object
-fastapi_stub.WebSocketDisconnect = type('WebSocketDisconnect', (), {})
-class HTTPException(Exception):
-    pass
-fastapi_stub.HTTPException = HTTPException
-sys.modules.setdefault('fastapi', fastapi_stub)
+from tests.test_helpers import (
+    fastapi_stub,
+    cors_stub,
+    resp_stub,
+    pydantic_stub,
+    install_stubs,
+    FakeApp,
+)
 
-cors_stub = types.ModuleType('fastapi.middleware.cors')
-cors_stub.CORSMiddleware = object
-sys.modules.setdefault('fastapi.middleware.cors', cors_stub)
-
-resp_stub = types.ModuleType('fastapi.responses')
-resp_stub.HTMLResponse = object
-resp_stub.FileResponse = object
-sys.modules.setdefault('fastapi.responses', resp_stub)
-
-pydantic_stub = types.ModuleType('pydantic')
-class BaseModel:
-    pass
-pydantic_stub.BaseModel = BaseModel
-sys.modules.setdefault('pydantic', pydantic_stub)
+install_stubs()
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), 'Server'))

--- a/tests/test_process_hashes_jobs.py
+++ b/tests/test_process_hashes_jobs.py
@@ -1,49 +1,22 @@
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import asyncio
 import sys
 import os
-import types
 import json
 from pathlib import Path
+import types
 
-# Stub FastAPI and related modules
-fastapi_stub = types.ModuleType('fastapi')
-class FakeApp:
-    def add_middleware(self, *a, **kw):
-        pass
-    def on_event(self, *a, **kw):
-        return lambda f: f
-    def post(self, *a, **kw):
-        return lambda f: f
-    def get(self, *a, **kw):
-        return lambda f: f
-    def delete(self, *a, **kw):
-        return lambda f: f
-    def websocket(self, *a, **kw):
-        return lambda f: f
-fastapi_stub.FastAPI = lambda: FakeApp()
-fastapi_stub.UploadFile = object
-fastapi_stub.File = lambda *a, **kw: None
-fastapi_stub.WebSocket = object
-fastapi_stub.WebSocketDisconnect = type('WebSocketDisconnect', (), {})
-class HTTPException(Exception):
-    pass
-fastapi_stub.HTTPException = HTTPException
-sys.modules.setdefault('fastapi', fastapi_stub)
+from tests.test_helpers import (
+    fastapi_stub,
+    cors_stub,
+    resp_stub,
+    pydantic_stub,
+    install_stubs,
+    FakeApp,
+)
 
-cors_stub = types.ModuleType('fastapi.middleware.cors')
-cors_stub.CORSMiddleware = object
-sys.modules.setdefault('fastapi.middleware.cors', cors_stub)
-
-resp_stub = types.ModuleType('fastapi.responses')
-resp_stub.HTMLResponse = object
-resp_stub.FileResponse = object
-sys.modules.setdefault('fastapi.responses', resp_stub)
-
-pydantic_stub = types.ModuleType('pydantic')
-class BaseModel:
-    pass
-pydantic_stub.BaseModel = BaseModel
-sys.modules.setdefault('pydantic', pydantic_stub)
+install_stubs()
 
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))

--- a/tests/test_server_filepaths.py
+++ b/tests/test_server_filepaths.py
@@ -1,49 +1,21 @@
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import asyncio
 import sys
 import os
-import types
 from pathlib import Path
 import sqlite3
 
-# Stub modules as in other server tests
-fastapi_stub = types.ModuleType("fastapi")
-class FakeApp:
-    def add_middleware(self, *a, **kw):
-        pass
-    def on_event(self, *a, **kw):
-        return lambda f: f
-    def post(self, *a, **kw):
-        return lambda f: f
-    def get(self, *a, **kw):
-        return lambda f: f
-    def delete(self, *a, **kw):
-        return lambda f: f
-    def websocket(self, *a, **kw):
-        return lambda f: f
-fastapi_stub.FastAPI = lambda: FakeApp()
-fastapi_stub.UploadFile = object
-fastapi_stub.File = lambda *a, **kw: None
-fastapi_stub.WebSocket = object
-fastapi_stub.WebSocketDisconnect = type("WebSocketDisconnect", (), {})
-class HTTPException(Exception):
-    pass
-fastapi_stub.HTTPException = HTTPException
-sys.modules.setdefault("fastapi", fastapi_stub)
+from tests.test_helpers import (
+    fastapi_stub,
+    cors_stub,
+    resp_stub,
+    pydantic_stub,
+    install_stubs,
+    FakeApp,
+)
 
-cors_stub = types.ModuleType("fastapi.middleware.cors")
-cors_stub.CORSMiddleware = object
-sys.modules.setdefault("fastapi.middleware.cors", cors_stub)
-
-resp_stub = types.ModuleType("fastapi.responses")
-resp_stub.HTMLResponse = object
-resp_stub.FileResponse = object
-sys.modules.setdefault("fastapi.responses", resp_stub)
-
-pydantic_stub = types.ModuleType("pydantic")
-class BaseModel:
-    pass
-pydantic_stub.BaseModel = BaseModel
-sys.modules.setdefault("pydantic", pydantic_stub)
+install_stubs()
 
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))

--- a/tests/test_server_found_map.py
+++ b/tests/test_server_found_map.py
@@ -1,49 +1,21 @@
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import asyncio
 import sys
 import os
-import types
 from pathlib import Path
 import threading
 
-# Stub FastAPI and Pydantic as in other server tests
-fastapi_stub = types.ModuleType("fastapi")
-class FakeApp:
-    def add_middleware(self, *a, **kw):
-        pass
-    def on_event(self, *a, **kw):
-        return lambda f: f
-    def post(self, *a, **kw):
-        return lambda f: f
-    def get(self, *a, **kw):
-        return lambda f: f
-    def delete(self, *a, **kw):
-        return lambda f: f
-    def websocket(self, *a, **kw):
-        return lambda f: f
-fastapi_stub.FastAPI = lambda: FakeApp()
-fastapi_stub.UploadFile = object
-fastapi_stub.File = lambda *a, **kw: None
-fastapi_stub.WebSocket = object
-fastapi_stub.WebSocketDisconnect = type("WebSocketDisconnect", (), {})
-class HTTPException(Exception):
-    pass
-fastapi_stub.HTTPException = HTTPException
-sys.modules.setdefault("fastapi", fastapi_stub)
+from tests.test_helpers import (
+    fastapi_stub,
+    cors_stub,
+    resp_stub,
+    pydantic_stub,
+    install_stubs,
+    FakeApp,
+)
 
-cors_stub = types.ModuleType("fastapi.middleware.cors")
-cors_stub.CORSMiddleware = object
-sys.modules.setdefault("fastapi.middleware.cors", cors_stub)
-
-resp_stub = types.ModuleType("fastapi.responses")
-resp_stub.HTMLResponse = object
-resp_stub.FileResponse = object
-sys.modules.setdefault("fastapi.responses", resp_stub)
-
-pydantic_stub = types.ModuleType("pydantic")
-class BaseModel:
-    pass
-pydantic_stub.BaseModel = BaseModel
-sys.modules.setdefault("pydantic", pydantic_stub)
+install_stubs()
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), "Server"))

--- a/tests/test_server_get_batch.py
+++ b/tests/test_server_get_batch.py
@@ -1,64 +1,19 @@
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import asyncio
 import sys
 import os
-import types
 
-# Stub FastAPI and related modules just like in test_server_register
-fastapi_stub = types.ModuleType("fastapi")
+from tests.test_helpers import (
+    fastapi_stub,
+    cors_stub,
+    resp_stub,
+    pydantic_stub,
+    install_stubs,
+    FakeApp,
+)
 
-
-class FakeApp:
-    def add_middleware(self, *a, **kw):
-        pass
-
-    def on_event(self, *a, **kw):
-        return lambda f: f
-
-    def post(self, *a, **kw):
-        return lambda f: f
-
-    def get(self, *a, **kw):
-        return lambda f: f
-
-    def delete(self, *a, **kw):
-        return lambda f: f
-
-    def websocket(self, *a, **kw):
-        return lambda f: f
-
-
-fastapi_stub.FastAPI = lambda: FakeApp()
-fastapi_stub.UploadFile = object
-fastapi_stub.File = lambda *a, **kw: None
-fastapi_stub.WebSocket = object
-fastapi_stub.WebSocketDisconnect = type("WebSocketDisconnect", (), {})
-
-
-class HTTPException(Exception):
-    pass
-
-
-fastapi_stub.HTTPException = HTTPException
-sys.modules.setdefault("fastapi", fastapi_stub)
-
-cors_stub = types.ModuleType("fastapi.middleware.cors")
-cors_stub.CORSMiddleware = object
-sys.modules.setdefault("fastapi.middleware.cors", cors_stub)
-
-resp_stub = types.ModuleType("fastapi.responses")
-resp_stub.HTMLResponse = object
-resp_stub.FileResponse = object
-sys.modules.setdefault("fastapi.responses", resp_stub)
-
-pydantic_stub = types.ModuleType("pydantic")
-
-
-class BaseModel:
-    pass
-
-
-pydantic_stub.BaseModel = BaseModel
-sys.modules.setdefault("pydantic", pydantic_stub)
+install_stubs()
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), "Server"))

--- a/tests/test_server_import_hashes.py
+++ b/tests/test_server_import_hashes.py
@@ -1,50 +1,21 @@
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import asyncio
 import sys
 import os
-import types
 import json
 import pytest
 
-# Stub modules as in other server tests
-fastapi_stub = types.ModuleType("fastapi")
-class FakeApp:
-    def add_middleware(self, *a, **kw):
-        pass
-    def on_event(self, *a, **kw):
-        return lambda f: f
-    def post(self, *a, **kw):
-        return lambda f: f
-    def get(self, *a, **kw):
-        return lambda f: f
-    def delete(self, *a, **kw):
-        return lambda f: f
-    def websocket(self, *a, **kw):
-        return lambda f: f
-fastapi_stub.FastAPI = lambda: FakeApp()
-fastapi_stub.UploadFile = object
-fastapi_stub.File = lambda *a, **kw: None
-fastapi_stub.WebSocket = object
-fastapi_stub.WebSocketDisconnect = type("WebSocketDisconnect", (), {})
-class HTTPException(Exception):
-    def __init__(self, *a, **kw):
-        super().__init__(*a)
-fastapi_stub.HTTPException = HTTPException
-sys.modules.setdefault("fastapi", fastapi_stub)
+from tests.test_helpers import (
+    fastapi_stub,
+    cors_stub,
+    resp_stub,
+    pydantic_stub,
+    install_stubs,
+    FakeApp,
+)
 
-cors_stub = types.ModuleType("fastapi.middleware.cors")
-cors_stub.CORSMiddleware = object
-sys.modules.setdefault("fastapi.middleware.cors", cors_stub)
-
-resp_stub = types.ModuleType("fastapi.responses")
-resp_stub.HTMLResponse = object
-resp_stub.FileResponse = object
-sys.modules.setdefault("fastapi.responses", resp_stub)
-
-pydantic_stub = types.ModuleType("pydantic")
-class BaseModel:
-    pass
-pydantic_stub.BaseModel = BaseModel
-sys.modules.setdefault("pydantic", pydantic_stub)
+install_stubs()
 
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))

--- a/tests/test_server_llm.py
+++ b/tests/test_server_llm.py
@@ -1,47 +1,20 @@
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import asyncio
 import sys
 import os
 import types
 
-# Stub FastAPI and Pydantic like other server tests
-fastapi_stub = types.ModuleType("fastapi")
-class FakeApp:
-    def add_middleware(self, *a, **kw):
-        pass
-    def on_event(self, *a, **kw):
-        return lambda f: f
-    def post(self, *a, **kw):
-        return lambda f: f
-    def get(self, *a, **kw):
-        return lambda f: f
-    def delete(self, *a, **kw):
-        return lambda f: f
-    def websocket(self, *a, **kw):
-        return lambda f: f
-fastapi_stub.FastAPI = lambda: FakeApp()
-fastapi_stub.UploadFile = object
-fastapi_stub.File = lambda *a, **kw: None
-fastapi_stub.WebSocket = object
-fastapi_stub.WebSocketDisconnect = type("WebSocketDisconnect", (), {})
-class HTTPException(Exception):
-    pass
-fastapi_stub.HTTPException = HTTPException
-sys.modules.setdefault("fastapi", fastapi_stub)
+from tests.test_helpers import (
+    fastapi_stub,
+    cors_stub,
+    resp_stub,
+    pydantic_stub,
+    install_stubs,
+    FakeApp,
+)
 
-cors_stub = types.ModuleType("fastapi.middleware.cors")
-cors_stub.CORSMiddleware = object
-sys.modules.setdefault("fastapi.middleware.cors", cors_stub)
-
-resp_stub = types.ModuleType("fastapi.responses")
-resp_stub.HTMLResponse = object
-resp_stub.FileResponse = object
-sys.modules.setdefault("fastapi.responses", resp_stub)
-
-pydantic_stub = types.ModuleType("pydantic")
-class BaseModel:
-    pass
-pydantic_stub.BaseModel = BaseModel
-sys.modules.setdefault("pydantic", pydantic_stub)
+install_stubs()
 
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))

--- a/tests/test_server_markov.py
+++ b/tests/test_server_markov.py
@@ -1,47 +1,20 @@
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import asyncio
 import sys
 import os
 import types
 
-# Stub FastAPI and Pydantic like other server tests
-fastapi_stub = types.ModuleType("fastapi")
-class FakeApp:
-    def add_middleware(self, *a, **kw):
-        pass
-    def on_event(self, *a, **kw):
-        return lambda f: f
-    def post(self, *a, **kw):
-        return lambda f: f
-    def get(self, *a, **kw):
-        return lambda f: f
-    def delete(self, *a, **kw):
-        return lambda f: f
-    def websocket(self, *a, **kw):
-        return lambda f: f
-fastapi_stub.FastAPI = lambda: FakeApp()
-fastapi_stub.UploadFile = object
-fastapi_stub.File = lambda *a, **kw: None
-fastapi_stub.WebSocket = object
-fastapi_stub.WebSocketDisconnect = type("WebSocketDisconnect", (), {})
-class HTTPException(Exception):
-    pass
-fastapi_stub.HTTPException = HTTPException
-sys.modules.setdefault("fastapi", fastapi_stub)
+from tests.test_helpers import (
+    fastapi_stub,
+    cors_stub,
+    resp_stub,
+    pydantic_stub,
+    install_stubs,
+    FakeApp,
+)
 
-cors_stub = types.ModuleType("fastapi.middleware.cors")
-cors_stub.CORSMiddleware = object
-sys.modules.setdefault("fastapi.middleware.cors", cors_stub)
-
-resp_stub = types.ModuleType("fastapi.responses")
-resp_stub.HTMLResponse = object
-resp_stub.FileResponse = object
-sys.modules.setdefault("fastapi.responses", resp_stub)
-
-pydantic_stub = types.ModuleType("pydantic")
-class BaseModel:
-    pass
-pydantic_stub.BaseModel = BaseModel
-sys.modules.setdefault("pydantic", pydantic_stub)
+install_stubs()
 
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))

--- a/tests/test_server_register.py
+++ b/tests/test_server_register.py
@@ -1,48 +1,20 @@
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import asyncio
 import sys
 import os
-import types
 import pytest
 
-# Stub out FastAPI and Pydantic to avoid heavy dependencies during testing
-fastapi_stub = types.ModuleType("fastapi")
-class FakeApp:
-    def add_middleware(self, *a, **kw):
-        pass
-    def on_event(self, *a, **kw):
-        return lambda f: f
-    def post(self, *a, **kw):
-        return lambda f: f
-    def get(self, *a, **kw):
-        return lambda f: f
-    def delete(self, *a, **kw):
-        return lambda f: f
-    def websocket(self, *a, **kw):
-        return lambda f: f
-fastapi_stub.FastAPI = lambda: FakeApp()
-fastapi_stub.UploadFile = object
-fastapi_stub.File = lambda *a, **kw: None
-fastapi_stub.WebSocket = object
-fastapi_stub.WebSocketDisconnect = type("WebSocketDisconnect", (), {})
-class HTTPException(Exception):
-    pass
-fastapi_stub.HTTPException = HTTPException
-sys.modules.setdefault("fastapi", fastapi_stub)
+from tests.test_helpers import (
+    fastapi_stub,
+    cors_stub,
+    resp_stub,
+    pydantic_stub,
+    install_stubs,
+    FakeApp,
+)
 
-cors_stub = types.ModuleType("fastapi.middleware.cors")
-cors_stub.CORSMiddleware = object
-sys.modules.setdefault("fastapi.middleware.cors", cors_stub)
-
-resp_stub = types.ModuleType("fastapi.responses")
-resp_stub.HTMLResponse = object
-resp_stub.FileResponse = object
-sys.modules.setdefault("fastapi.responses", resp_stub)
-
-pydantic_stub = types.ModuleType("pydantic")
-class BaseModel:
-    pass
-pydantic_stub.BaseModel = BaseModel
-sys.modules.setdefault("pydantic", pydantic_stub)
+install_stubs()
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), 'Server'))

--- a/tests/test_server_status.py
+++ b/tests/test_server_status.py
@@ -1,47 +1,20 @@
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import asyncio
 import sys
 import os
 import types
 
-# Stub FastAPI and Pydantic similar to other server tests
-fastapi_stub = types.ModuleType("fastapi")
-class FakeApp:
-    def add_middleware(self, *a, **kw):
-        pass
-    def on_event(self, *a, **kw):
-        return lambda f: f
-    def post(self, *a, **kw):
-        return lambda f: f
-    def get(self, *a, **kw):
-        return lambda f: f
-    def delete(self, *a, **kw):
-        return lambda f: f
-    def websocket(self, *a, **kw):
-        return lambda f: f
-fastapi_stub.FastAPI = lambda: FakeApp()
-fastapi_stub.UploadFile = object
-fastapi_stub.File = lambda *a, **kw: None
-fastapi_stub.WebSocket = object
-fastapi_stub.WebSocketDisconnect = type("WebSocketDisconnect", (), {})
-class HTTPException(Exception):
-    pass
-fastapi_stub.HTTPException = HTTPException
-sys.modules.setdefault("fastapi", fastapi_stub)
+from tests.test_helpers import (
+    fastapi_stub,
+    cors_stub,
+    resp_stub,
+    pydantic_stub,
+    install_stubs,
+    FakeApp,
+)
 
-cors_stub = types.ModuleType("fastapi.middleware.cors")
-cors_stub.CORSMiddleware = object
-sys.modules.setdefault("fastapi.middleware.cors", cors_stub)
-
-resp_stub = types.ModuleType("fastapi.responses")
-resp_stub.HTMLResponse = object
-resp_stub.FileResponse = object
-sys.modules.setdefault("fastapi.responses", resp_stub)
-
-pydantic_stub = types.ModuleType("pydantic")
-class BaseModel:
-    pass
-pydantic_stub.BaseModel = BaseModel
-sys.modules.setdefault("pydantic", pydantic_stub)
+install_stubs()
 
 # Stub cryptography pieces used by auth_utils
 

--- a/tests/test_server_submit_benchmark.py
+++ b/tests/test_server_submit_benchmark.py
@@ -1,46 +1,19 @@
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import asyncio
 import sys
 import os
-import types
 
-# Stub FastAPI and pydantic like other server tests
-fastapi_stub = types.ModuleType("fastapi")
-class FakeApp:
-    def add_middleware(self, *a, **kw):
-        pass
-    def on_event(self, *a, **kw):
-        return lambda f: f
-    def post(self, *a, **kw):
-        return lambda f: f
-    def get(self, *a, **kw):
-        return lambda f: f
-    def delete(self, *a, **kw):
-        return lambda f: f
-    def websocket(self, *a, **kw):
-        return lambda f: f
-fastapi_stub.FastAPI = lambda: FakeApp()
-fastapi_stub.UploadFile = object
-fastapi_stub.File = lambda *a, **kw: None
-fastapi_stub.WebSocket = object
-fastapi_stub.WebSocketDisconnect = type("WebSocketDisconnect", (), {})
-class HTTPException(Exception):
-    pass
-fastapi_stub.HTTPException = HTTPException
-sys.modules.setdefault("fastapi", fastapi_stub)
+from tests.test_helpers import (
+    fastapi_stub,
+    cors_stub,
+    resp_stub,
+    pydantic_stub,
+    install_stubs,
+    FakeApp,
+)
 
-cors_stub = types.ModuleType("fastapi.middleware.cors")
-cors_stub.CORSMiddleware = object
-sys.modules.setdefault("fastapi.middleware.cors", cors_stub)
-
-resp_stub = types.ModuleType("fastapi.responses")
-resp_stub.HTMLResponse = object
-sys.modules.setdefault("fastapi.responses", resp_stub)
-
-pydantic_stub = types.ModuleType("pydantic")
-class BaseModel:
-    pass
-pydantic_stub.BaseModel = BaseModel
-sys.modules.setdefault("pydantic", pydantic_stub)
+install_stubs()
 
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))

--- a/tests/test_server_train_llm.py
+++ b/tests/test_server_train_llm.py
@@ -1,47 +1,20 @@
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import asyncio
 import sys
 import os
 import types
 
-# Stub FastAPI and Pydantic like other server tests
-fastapi_stub = types.ModuleType("fastapi")
-class FakeApp:
-    def add_middleware(self, *a, **kw):
-        pass
-    def on_event(self, *a, **kw):
-        return lambda f: f
-    def post(self, *a, **kw):
-        return lambda f: f
-    def get(self, *a, **kw):
-        return lambda f: f
-    def delete(self, *a, **kw):
-        return lambda f: f
-    def websocket(self, *a, **kw):
-        return lambda f: f
-fastapi_stub.FastAPI = lambda: FakeApp()
-fastapi_stub.UploadFile = object
-fastapi_stub.File = lambda *a, **kw: None
-fastapi_stub.WebSocket = object
-fastapi_stub.WebSocketDisconnect = type("WebSocketDisconnect", (), {})
-class HTTPException(Exception):
-    pass
-fastapi_stub.HTTPException = HTTPException
-sys.modules.setdefault("fastapi", fastapi_stub)
+from tests.test_helpers import (
+    fastapi_stub,
+    cors_stub,
+    resp_stub,
+    pydantic_stub,
+    install_stubs,
+    FakeApp,
+)
 
-cors_stub = types.ModuleType("fastapi.middleware.cors")
-cors_stub.CORSMiddleware = object
-sys.modules.setdefault("fastapi.middleware.cors", cors_stub)
-
-resp_stub = types.ModuleType("fastapi.responses")
-resp_stub.HTMLResponse = object
-resp_stub.FileResponse = object
-sys.modules.setdefault("fastapi.responses", resp_stub)
-
-pydantic_stub = types.ModuleType("pydantic")
-class BaseModel:
-    pass
-pydantic_stub.BaseModel = BaseModel
-sys.modules.setdefault("pydantic", pydantic_stub)
+install_stubs()
 
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))

--- a/tests/test_shutdown_tasks.py
+++ b/tests/test_shutdown_tasks.py
@@ -1,48 +1,20 @@
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import asyncio
 import sys
 import os
-import types
 import pytest
 
-# Minimal FastAPI stubs to avoid heavy dependencies
-fastapi_stub = types.ModuleType("fastapi")
-class FakeApp:
-    def add_middleware(self, *a, **kw):
-        pass
-    def on_event(self, *a, **kw):
-        return lambda f: f
-    def post(self, *a, **kw):
-        return lambda f: f
-    def get(self, *a, **kw):
-        return lambda f: f
-    def delete(self, *a, **kw):
-        return lambda f: f
-    def websocket(self, *a, **kw):
-        return lambda f: f
-fastapi_stub.FastAPI = lambda: FakeApp()
-fastapi_stub.UploadFile = object
-fastapi_stub.File = lambda *a, **kw: None
-fastapi_stub.WebSocket = object
-fastapi_stub.WebSocketDisconnect = type("WebSocketDisconnect", (), {})
-class HTTPException(Exception):
-    pass
-fastapi_stub.HTTPException = HTTPException
-sys.modules.setdefault("fastapi", fastapi_stub)
+from tests.test_helpers import (
+    fastapi_stub,
+    cors_stub,
+    resp_stub,
+    pydantic_stub,
+    install_stubs,
+    FakeApp,
+)
 
-cors_stub = types.ModuleType("fastapi.middleware.cors")
-cors_stub.CORSMiddleware = object
-sys.modules.setdefault("fastapi.middleware.cors", cors_stub)
-
-resp_stub = types.ModuleType("fastapi.responses")
-resp_stub.HTMLResponse = object
-resp_stub.FileResponse = object
-sys.modules.setdefault("fastapi.responses", resp_stub)
-
-pydantic_stub = types.ModuleType("pydantic")
-class BaseModel:
-    pass
-pydantic_stub.BaseModel = BaseModel
-sys.modules.setdefault("pydantic", pydantic_stub)
+install_stubs()
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), 'Server'))

--- a/tests/test_wordlist_db.py
+++ b/tests/test_wordlist_db.py
@@ -1,68 +1,23 @@
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import asyncio
 import sys
 import os
-import types
 import sqlite3
 import json
 import base64
 import gzip
 
-# Stub modules similar to other server tests
-fastapi_stub = types.ModuleType("fastapi")
+from tests.test_helpers import (
+    fastapi_stub,
+    cors_stub,
+    resp_stub,
+    pydantic_stub,
+    install_stubs,
+    FakeApp,
+)
 
-
-class FakeApp:
-    def add_middleware(self, *a, **kw):
-        pass
-
-    def on_event(self, *a, **kw):
-        return lambda f: f
-
-    def post(self, *a, **kw):
-        return lambda f: f
-
-    def get(self, *a, **kw):
-        return lambda f: f
-
-    def delete(self, *a, **kw):
-        return lambda f: f
-
-    def websocket(self, *a, **kw):
-        return lambda f: f
-
-
-fastapi_stub.FastAPI = lambda: FakeApp()
-fastapi_stub.UploadFile = object
-fastapi_stub.File = lambda *a, **kw: None
-fastapi_stub.WebSocket = object
-fastapi_stub.WebSocketDisconnect = type("WebSocketDisconnect", (), {})
-
-
-class HTTPException(Exception):
-    pass
-
-
-fastapi_stub.HTTPException = HTTPException
-sys.modules.setdefault("fastapi", fastapi_stub)
-
-cors_stub = types.ModuleType("fastapi.middleware.cors")
-cors_stub.CORSMiddleware = object
-sys.modules.setdefault("fastapi.middleware.cors", cors_stub)
-
-resp_stub = types.ModuleType("fastapi.responses")
-resp_stub.HTMLResponse = object
-resp_stub.FileResponse = object
-sys.modules.setdefault("fastapi.responses", resp_stub)
-
-pydantic_stub = types.ModuleType("pydantic")
-
-
-class BaseModel:
-    pass
-
-
-pydantic_stub.BaseModel = BaseModel
-sys.modules.setdefault("pydantic", pydantic_stub)
+install_stubs()
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), "Server"))


### PR DESCRIPTION
## Summary
- share FastAPI/Pydantic stubs in `tests/test_helpers.py`
- update server tests to import the shared helpers

## Testing
- `pip install -r Server/requirements-dev.txt`
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688426f0fdcc8326a5ea3c89c0bee64c