### PR TITLE
Replace prints with logging

### DIFF
--- a/Server/event_logger.py
+++ b/Server/event_logger.py
@@ -3,6 +3,7 @@ from redis_utils import get_redis
 import json
 import traceback
 from datetime import datetime
+import logging
 
 r = get_redis()
 
@@ -25,7 +26,7 @@ def log_event(
         r.rpush(f"error_logs:{worker_id}", json.dumps(event))
         r.ltrim(f"error_logs:{worker_id}", -100, -1)  # Keep last 100 logs
     except redis.exceptions.RedisError:
-        print("Redis unavailable: log_event", event)
+        logging.warning("Redis unavailable: log_event %s", event)
 
 
 def log_error(component, worker_id, code, message, exception=None):
@@ -52,4 +53,4 @@ def log_watchdog_event(payload: dict):
         r.rpush(f"watchdog_events:{worker_id}", json.dumps(event))
         r.ltrim(f"watchdog_events:{worker_id}", -100, -1)
     except redis.exceptions.RedisError:
-        print("Redis unavailable: log_watchdog_event", event)
+        logging.warning("Redis unavailable: log_watchdog_event %s", event)

--- a/Server/hashescom_client.py
+++ b/Server/hashescom_client.py
@@ -2,6 +2,7 @@ import asyncio
 import os
 import json
 from pathlib import Path
+import logging
 
 import requests
 
@@ -56,7 +57,7 @@ async def fetch_jobs() -> list:
             return await _fetch_jobs_async(url, headers)
         return await asyncio.to_thread(_fetch_jobs_sync, url, headers)
     except Exception as e:
-        print(f"[❌] Hashes.com fetch error: {e}")
+        logging.warning("[❌] Hashes.com fetch error: %s", e)
         return []
 
 
@@ -71,12 +72,12 @@ def upload_founds(algo_id, found_file) -> bool:
         resp.raise_for_status()
         result = resp.json()
         if not result.get("success"):
-            print(f"[❌] Upload rejected: {result}")
+            logging.warning("[❌] Upload rejected: %s", result)
             return False
         return True
     except requests.HTTPError as e:
-        print(f"[❌] Upload error: {e}")
+        logging.warning("[❌] Upload error: %s", e)
         return False
     except Exception as e:
-        print(f"[❌] Upload error: {e}")
+        logging.warning("[❌] Upload error: %s", e)
         return False

--- a/Server/main.py
+++ b/Server/main.py
@@ -8,6 +8,9 @@ from fastapi import (
 )
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import HTMLResponse, FileResponse
+import logging
+
+logging.basicConfig(level=logging.INFO)
 import subprocess
 from datetime import datetime
 import os

--- a/Server/redis_manager.py
+++ b/Server/redis_manager.py
@@ -3,6 +3,7 @@ from redis_utils import get_redis
 import json
 import uuid
 import time
+import logging
 import orchestrator_agent
 
 r = get_redis()
@@ -50,7 +51,7 @@ def store_batch(
             r.sadd(f"hash_batches:{h}", batch_id)
             r.expire(f"hash_batches:{h}", ttl)
     except redis.exceptions.RedisError as e:
-        print(f"Redis unavailable: {e}")
+        logging.warning("Redis unavailable: %s", e)
         return None
     return batch_id
 
@@ -64,7 +65,7 @@ def get_next_batch():
         data["batch_id"] = batch_id
         return data
     except redis.exceptions.RedisError as e:
-        print(f"Redis unavailable: {e}")
+        logging.warning("Redis unavailable: %s", e)
         return None
 
 
@@ -75,7 +76,7 @@ def requeue_batch(batch_id):
         if prio and int(prio) > 0:
             r.zadd("batch:prio", {batch_id: int(prio)})
     except redis.exceptions.RedisError as e:
-        print(f"Redis unavailable: {e}")
+        logging.warning("Redis unavailable: %s", e)
 
 
 def queue_range(batch_id: str, start: int, end: int) -> None:

--- a/Worker/hashmancer_worker/gpu_sidecar.py
+++ b/Worker/hashmancer_worker/gpu_sidecar.py
@@ -2,6 +2,7 @@ import os
 import time
 import threading
 import redis
+import logging
 
 try:
     from redis.exceptions import RedisError
@@ -153,8 +154,11 @@ class GPUSidecar(threading.Thread):
             except FileNotFoundError:
                 continue
             except Exception as e:
-                print(
-                    f"Failed to set power limit using {' '.join(cmd)} on {self.gpu.get('uuid')}: {e}"
+                logging.warning(
+                    "Failed to set power limit using %s on %s: %s",
+                    " ".join(cmd),
+                    self.gpu.get("uuid"),
+                    e,
                 )
                 return
 
@@ -177,7 +181,7 @@ class GPUSidecar(threading.Thread):
                         continue
                     self.execute_job(data)
                 except Exception as e:
-                    print(f"Sidecar error on {self.gpu['uuid']}: {e}")
+                    logging.warning("Sidecar error on %s: %s", self.gpu['uuid'], e)
                     time.sleep(5)
         finally:
             self.darkling_ctx.cleanup()
@@ -209,7 +213,7 @@ class GPUSidecar(threading.Thread):
                 except Exception:
                     pass
 
-        print(f"GPU {self.gpu['uuid']} processing {batch_id}")
+        logging.info("GPU %s processing %s", self.gpu['uuid'], batch_id)
         if (
             self.gpu.get("pci_link_width", self.gpu.get("pci_width", 16)) <= 4
             and self.low_bw_engine == "darkling"
@@ -245,7 +249,7 @@ class GPUSidecar(threading.Thread):
         try:
             requests.post(f"{self.server_url}/{endpoint}", json=payload, timeout=10)
         except Exception as e:
-            print(f"Result submission failed: {e}")
+            logging.warning("Result submission failed: %s", e)
 
         self.current_job = None
 
@@ -532,7 +536,12 @@ def run_hashcat_benchmark(gpu: dict, engine: str = "hashcat") -> dict[str, float
         try:
             output = subprocess.check_output(cmd, stderr=subprocess.STDOUT, text=True)
         except Exception as e:
-            print(f"Benchmark failed for {gpu.get('uuid')} mode {mode}: {e}")
+            logging.warning(
+                "Benchmark failed for %s mode %s: %s",
+                gpu.get("uuid"),
+                mode,
+                e,
+            )
             results[name] = 0.0
             continue
 
@@ -604,7 +613,12 @@ def run_darkling_benchmark(gpu: dict) -> dict[str, float]:
                 except json.JSONDecodeError:
                     continue
         except Exception as e:
-            print(f"Benchmark failed for {gpu.get('uuid')} mode {mode}: {e}")
+            logging.warning(
+                "Benchmark failed for %s mode %s: %s",
+                gpu.get("uuid"),
+                mode,
+                e,
+            )
             rate = 0.0
         results[name] = rate
     return results


### PR DESCRIPTION
## Summary
- standardize logging output for server and worker utilities
- configure logging in main scripts
- update redis and hashes.com helpers
- log GPU sidecar events instead of printing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688433b8eca88326952b4b6cb56c7268