### PR TITLE
Add CI workflow to run tests

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,19 @@
+name: Python Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: pip install -r Server/requirements.txt -r Worker/requirements.txt -r Server/requirements-dev.txt
+      - name: Run tests
+        run: pytest -q


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run pytest on Python 3.11

## Testing
- `pip install -r Server/requirements.txt -r Worker/requirements.txt -r Server/requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68843570add88326a2cc9d480c229c90