### PR TITLE
Add flake8 linting to workflow

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -15,5 +15,7 @@ jobs:
           python-version: '3.11'
       - name: Install dependencies
         run: pip install -r Server/requirements.txt -r Worker/requirements.txt -r Server/requirements-dev.txt
+      - name: Run flake8
+        run: flake8 .
       - name: Run tests
         run: pytest -q

--- a/Server/requirements-dev.txt
+++ b/Server/requirements-dev.txt
@@ -1,3 +1,4 @@
 pytest
 pytest-asyncio
 httpx
+flake8


### PR DESCRIPTION
## Summary
- add `flake8` to dev dependencies
- run `flake8 .` in CI before executing tests

## Testing
- `flake8 .` *(fails: lots of lint errors)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68844c5c53508326925bb0e7bee61984