### PR TITLE
Add Dockerfile and server container docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install system packages required for building dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    gcc \
+    libffi-dev \
+    libssl-dev \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy the repository
+COPY . /app
+
+# Install Python dependencies for the server
+RUN pip install --no-cache-dir -r Server/requirements.txt
+
+# Expose the default uvicorn port
+EXPOSE 8000
+
+# Run the FastAPI server
+WORKDIR /app/Server
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/Server/README.md
+++ b/Server/README.md
@@ -97,6 +97,22 @@ sudo systemctl start hashmancer-server
 
 ---
 
+## 🐳 Docker
+
+Build the server image from the repository root:
+
+```bash
+docker build -t hashmancer .
+```
+
+Run the container and expose port 8000:
+
+```bash
+docker run -p 8000:8000 hashmancer
+```
+
+---
+
 ## 📊 Glyph Dashboard
 
 `main.py` now includes a tiny dashboard called **Glyph** that you can view from


### PR DESCRIPTION
## Summary
- add Dockerfile for running the FastAPI server
- document how to build and run the Docker container

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68844dcd339083268dd911ccac5b51cb