### PR TITLE
Use pytest fixture to set sys.path

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,23 @@
+import sys
+import os
+import pytest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(__file__))
+SERVER_PATH = os.path.join(REPO_ROOT, "Server")
+
+
+def _ensure_paths():
+    if REPO_ROOT not in sys.path:
+        sys.path.insert(0, REPO_ROOT)
+    if SERVER_PATH not in sys.path:
+        sys.path.insert(0, SERVER_PATH)
+
+
+_ensure_paths()
+
+
+@pytest.fixture(scope="session", autouse=True)
+def add_repo_to_path():
+    """Ensure repository paths are on sys.path once per session."""
+    _ensure_paths()
+    yield

--- a/tests/test_allowed_origins.py
+++ b/tests/test_allowed_origins.py
@@ -1,5 +1,4 @@
 import sys, os
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import os
 import sys
 import json
@@ -25,8 +24,6 @@ from tests.test_helpers import (
 install_stubs()
 
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), 'Server'))
 
 
 def test_allowed_origins_applied(monkeypatch, tmp_path):

--- a/tests/test_auth_middleware.py
+++ b/tests/test_auth_middleware.py
@@ -1,5 +1,4 @@
 import sys, os
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import asyncio
 import json
 import sys
@@ -19,8 +18,6 @@ install_stubs()
 
 
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), "Server"))
 
 import main
 

--- a/tests/test_charsets.py
+++ b/tests/test_charsets.py
@@ -3,7 +3,6 @@ import sys
 import unicodedata
 
 ROOT = os.path.dirname(os.path.dirname(__file__))
-sys.path.insert(0, ROOT)
 
 from darkling import charsets
 

--- a/tests/test_darkling_backends.py
+++ b/tests/test_darkling_backends.py
@@ -4,7 +4,6 @@ import shutil
 import pytest
 
 ROOT = os.path.dirname(os.path.dirname(__file__))
-sys.path.insert(0, ROOT)
 
 try:
     import pyopencl as cl

--- a/tests/test_dispatch_loop.py
+++ b/tests/test_dispatch_loop.py
@@ -1,5 +1,4 @@
 import sys, os
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import asyncio
 import sys
 import os
@@ -17,8 +16,6 @@ install_stubs()
 
 
 # Add repo paths
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), 'Server'))
 
 import main
 import orchestrator_agent

--- a/tests/test_flash_queue.py
+++ b/tests/test_flash_queue.py
@@ -1,5 +1,4 @@
 import sys, os
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import asyncio
 import sys
 import os
@@ -15,8 +14,6 @@ from tests.test_helpers import (
 
 install_stubs()
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), "Server"))
 
 import main
 

--- a/tests/test_flash_tuner.py
+++ b/tests/test_flash_tuner.py
@@ -1,6 +1,5 @@
 import sys
 import os
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 from Worker.hashmancer_worker import flash_tuner
 

--- a/tests/test_gpu_flasher.py
+++ b/tests/test_gpu_flasher.py
@@ -2,7 +2,6 @@ import sys
 import os
 import pytest
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 from Worker.hashmancer_worker import bios_flasher
 

--- a/tests/test_gpu_sidecar.py
+++ b/tests/test_gpu_sidecar.py
@@ -4,7 +4,6 @@ import json
 import pytest
 from pathlib import Path
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 from Worker.hashmancer_worker import gpu_sidecar
 

--- a/tests/test_hash_algos.py
+++ b/tests/test_hash_algos.py
@@ -1,5 +1,4 @@
 import sys, os
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import asyncio
 import sys
 import os
@@ -15,8 +14,6 @@ from tests.test_helpers import (
 
 install_stubs()
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), 'Server'))
 
 import main
 

--- a/tests/test_hashes_config.py
+++ b/tests/test_hashes_config.py
@@ -1,5 +1,4 @@
 import sys, os
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import asyncio
 import sys
 import os
@@ -15,8 +14,6 @@ from tests.test_helpers import (
 
 install_stubs()
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), 'Server'))
 
 import main
 

--- a/tests/test_hashes_poll.py
+++ b/tests/test_hashes_poll.py
@@ -1,5 +1,4 @@
 import sys, os
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import asyncio
 import sys
 
@@ -15,8 +14,6 @@ from tests.test_helpers import (
 install_stubs()
 
 
-sys.path.insert(0, '..')
-sys.path.insert(0, 'Server')
 import main
 import hashescom_client
 

--- a/tests/test_hashes_settings.py
+++ b/tests/test_hashes_settings.py
@@ -1,5 +1,4 @@
 import sys, os
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import asyncio
 import sys
 import os
@@ -16,8 +15,6 @@ from tests.test_helpers import (
 
 install_stubs()
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), 'Server'))
 
 import main
 

--- a/tests/test_hashescom_client.py
+++ b/tests/test_hashescom_client.py
@@ -2,7 +2,6 @@ import os
 import sys
 import asyncio
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 from Server import hashescom_client
 

--- a/tests/test_import_hashes.py
+++ b/tests/test_import_hashes.py
@@ -1,5 +1,4 @@
 import sys, os
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import asyncio
 import sys
 import os
@@ -17,8 +16,6 @@ from tests.test_helpers import (
 install_stubs()
 
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), 'Server'))
 
 import main
 import redis_manager

--- a/tests/test_language_patterns.py
+++ b/tests/test_language_patterns.py
@@ -2,8 +2,6 @@ import os
 import sys
 
 ROOT = os.path.dirname(os.path.dirname(__file__))
-sys.path.insert(0, ROOT)
-sys.path.insert(0, os.path.join(ROOT, "Server"))
 
 from Server import learn_trends
 from darkling import statistics

--- a/tests/test_llm_orchestrator.py
+++ b/tests/test_llm_orchestrator.py
@@ -3,8 +3,6 @@ import sys
 import json
 
 ROOT = os.path.dirname(os.path.dirname(__file__))
-sys.path.insert(0, ROOT)
-sys.path.insert(0, os.path.join(ROOT, "Server"))
 
 import orchestrator_agent
 import redis_manager

--- a/tests/test_orchestrator_agent.py
+++ b/tests/test_orchestrator_agent.py
@@ -2,8 +2,6 @@ import os
 import sys
 
 ROOT = os.path.dirname(os.path.dirname(__file__))
-sys.path.insert(0, ROOT)
-sys.path.insert(0, os.path.join(ROOT, "Server"))
 import json
 import redis_manager
 

--- a/tests/test_pattern_to_mask.py
+++ b/tests/test_pattern_to_mask.py
@@ -2,8 +2,6 @@ import os
 import sys
 
 ROOT = os.path.dirname(os.path.dirname(__file__))
-sys.path.insert(0, ROOT)
-sys.path.insert(0, os.path.join(ROOT, "Server"))
 
 import pattern_to_mask
 

--- a/tests/test_pattern_utils.py
+++ b/tests/test_pattern_utils.py
@@ -3,7 +3,6 @@ import sys
 import pytest
 
 # Allow importing the Server package from the repository root
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 from Server.pattern_utils import word_to_pattern, is_valid_pattern, is_valid_word
 

--- a/tests/test_predefined_masks.py
+++ b/tests/test_predefined_masks.py
@@ -1,5 +1,4 @@
 import sys, os
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import asyncio
 import sys
 import os
@@ -15,8 +14,6 @@ from tests.test_helpers import (
 
 install_stubs()
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), 'Server'))
 
 import main
 

--- a/tests/test_process_hashes_jobs.py
+++ b/tests/test_process_hashes_jobs.py
@@ -1,5 +1,4 @@
 import sys, os
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import asyncio
 import sys
 import os
@@ -19,8 +18,6 @@ from tests.test_helpers import (
 install_stubs()
 
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), 'Server'))
 
 import main
 import redis_manager

--- a/tests/test_redis_manager.py
+++ b/tests/test_redis_manager.py
@@ -4,8 +4,6 @@ import json
 from uuid import UUID
 
 ROOT = os.path.dirname(os.path.dirname(__file__))
-sys.path.insert(0, ROOT)
-sys.path.insert(0, os.path.join(ROOT, "Server"))
 
 import redis_manager
 

--- a/tests/test_server_filepaths.py
+++ b/tests/test_server_filepaths.py
@@ -1,5 +1,4 @@
 import sys, os
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import asyncio
 import sys
 import os
@@ -18,8 +17,6 @@ from tests.test_helpers import (
 install_stubs()
 
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), 'Server'))
 
 import main
 

--- a/tests/test_server_found_map.py
+++ b/tests/test_server_found_map.py
@@ -1,5 +1,4 @@
 import sys, os
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import asyncio
 import sys
 import os
@@ -17,8 +16,6 @@ from tests.test_helpers import (
 
 install_stubs()
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), "Server"))
 
 import main
 import redis_manager

--- a/tests/test_server_get_batch.py
+++ b/tests/test_server_get_batch.py
@@ -1,5 +1,4 @@
 import sys, os
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import asyncio
 import sys
 import os
@@ -15,8 +14,6 @@ from tests.test_helpers import (
 
 install_stubs()
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), "Server"))
 
 import main
 import redis_manager

--- a/tests/test_server_import_hashes.py
+++ b/tests/test_server_import_hashes.py
@@ -1,5 +1,4 @@
 import sys, os
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import asyncio
 import sys
 import os
@@ -18,8 +17,6 @@ from tests.test_helpers import (
 install_stubs()
 
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), 'Server'))
 
 import main
 import redis_manager

--- a/tests/test_server_llm.py
+++ b/tests/test_server_llm.py
@@ -1,5 +1,4 @@
 import sys, os
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import asyncio
 import sys
 import os
@@ -17,8 +16,6 @@ from tests.test_helpers import (
 install_stubs()
 
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), 'Server'))
 
 import main
 

--- a/tests/test_server_markov.py
+++ b/tests/test_server_markov.py
@@ -1,5 +1,4 @@
 import sys, os
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import asyncio
 import sys
 import os
@@ -17,8 +16,6 @@ from tests.test_helpers import (
 install_stubs()
 
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), 'Server'))
 
 import main
 

--- a/tests/test_server_register.py
+++ b/tests/test_server_register.py
@@ -1,5 +1,4 @@
 import sys, os
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import asyncio
 import sys
 import os
@@ -16,8 +15,6 @@ from tests.test_helpers import (
 
 install_stubs()
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), 'Server'))
 
 import main
 

--- a/tests/test_server_status.py
+++ b/tests/test_server_status.py
@@ -1,5 +1,4 @@
 import sys, os
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import asyncio
 import sys
 import os
@@ -26,8 +25,6 @@ psutil_stub.disk_usage = lambda path: types.SimpleNamespace(percent=30.0)
 psutil_stub.getloadavg = lambda: (1.0, 0.5, 0.25)
 sys.modules.setdefault("psutil", psutil_stub)
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), 'Server'))
 
 import main
 

--- a/tests/test_server_submit_benchmark.py
+++ b/tests/test_server_submit_benchmark.py
@@ -1,5 +1,4 @@
 import sys, os
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import asyncio
 import sys
 import os
@@ -16,8 +15,6 @@ from tests.test_helpers import (
 install_stubs()
 
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), 'Server'))
 
 import main
 

--- a/tests/test_server_train_llm.py
+++ b/tests/test_server_train_llm.py
@@ -1,5 +1,4 @@
 import sys, os
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import asyncio
 import sys
 import os
@@ -17,8 +16,6 @@ from tests.test_helpers import (
 install_stubs()
 
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), 'Server'))
 
 import main
 

--- a/tests/test_shutdown_tasks.py
+++ b/tests/test_shutdown_tasks.py
@@ -1,5 +1,4 @@
 import sys, os
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import asyncio
 import sys
 import os
@@ -16,8 +15,6 @@ from tests.test_helpers import (
 
 install_stubs()
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), 'Server'))
 
 import main
 

--- a/tests/test_sign_message_cache.py
+++ b/tests/test_sign_message_cache.py
@@ -7,8 +7,6 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.primitives import serialization
 
 ROOT = os.path.dirname(os.path.dirname(__file__))
-sys.path.insert(0, ROOT)
-sys.path.insert(0, os.path.join(ROOT, "Server"))
 
 
 def _make_key(path: Path) -> Path:

--- a/tests/test_sign_message_generation.py
+++ b/tests/test_sign_message_generation.py
@@ -4,8 +4,6 @@ import importlib
 from pathlib import Path
 
 ROOT = os.path.dirname(os.path.dirname(__file__))
-sys.path.insert(0, ROOT)
-sys.path.insert(0, os.path.join(ROOT, "Server"))
 
 
 def _run_worker(tmp_path: Path):

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -2,8 +2,6 @@ import os
 import sys
 
 ROOT = os.path.dirname(os.path.dirname(__file__))
-sys.path.insert(0, ROOT)
-sys.path.insert(0, os.path.join(ROOT, "Server"))
 
 from darkling import statistics
 

--- a/tests/test_timestamp_signatures.py
+++ b/tests/test_timestamp_signatures.py
@@ -2,7 +2,6 @@ import importlib
 import types
 import sys
 
-sys.path.insert(0, 'Server')
 
 import auth_utils
 

--- a/tests/test_wordlist_db.py
+++ b/tests/test_wordlist_db.py
@@ -1,5 +1,4 @@
 import sys, os
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import asyncio
 import sys
 import os
@@ -19,8 +18,6 @@ from tests.test_helpers import (
 
 install_stubs()
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), "Server"))
 
 import main
 import orchestrator_agent

--- a/tests/test_worker_agent.py
+++ b/tests/test_worker_agent.py
@@ -1,8 +1,6 @@
 import sys
 import os
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), "Server"))
 
 from Worker.hashmancer_worker import worker_agent
 


### PR DESCRIPTION
## Summary
- add `add_repo_to_path` fixture for pytest
- remove all manual `sys.path.insert` calls from tests

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884ede076248326bdfb549c9a182aeb