### PR TITLE
Fix README worker references

### DIFF
--- a/Server/README.md
+++ b/Server/README.md
@@ -18,7 +18,7 @@ Hashmancer is a high-performance, distributed hash cracking orchestration system
 - Orchestration tools for AWS, Vast.ai, and on-prem deployments
 - Self-healing logic with watchdog and error reporting
 - Systemd service setup and optional cloud-init support
-- Worker and GPU agent code moved to [Hashmancer-Agent](https://github.com/infernal-Insights/hashmancer-agent)
+- Worker and GPU agent code is included in the [`Worker/`](../Worker) directory (setup instructions in [`Worker/README.md`](../Worker/README.md))
 - Agents handle PCIe-aware mask, dictionary, and hybrid attacks
 - GPU specs are stored in Redis for tuning
 - Each GPU spec includes a `pci_link_width` field used to route work
@@ -237,7 +237,7 @@ containing `dataset`, `base_model`, `epochs`, `learning_rate` and
 
 ## 🚀 Hashmancer Agent
 
-Worker and GPU agent code has moved to the [Hashmancer-Agent](https://github.com/infernal-Insights/hashmancer-agent) repository. Refer to that repo for worker setup and environment variables.
+The worker and GPU agent code is included in this repository under [`Worker/`](../Worker). Refer to [`Worker/README.md`](../Worker/README.md) for worker setup instructions and environment variables.
 
 ### Auto-discovery snippet
 


### PR DESCRIPTION
## Summary
- clarify where worker code lives in the features list
- mention Worker/README.md for worker setup instructions

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884f1d203cc8326b0ac022a09f99c8a