### PR TITLE
Refactor background task loops

### DIFF
--- a/Server/app/background/__init__.py
+++ b/Server/app/background/__init__.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+import asyncio
+from typing import Iterable, List
+
+from app.config import BROADCAST_ENABLED
+
+from .broadcast import broadcast_presence
+from .hashes_jobs import poll_hashes_jobs, process_hashes_jobs
+from .hashes_jobs import fetch_and_store_jobs  # re-export for convenience
+from .dispatch import dispatch_loop
+
+__all__ = [
+    "broadcast_presence",
+    "fetch_and_store_jobs",
+    "poll_hashes_jobs",
+    "process_hashes_jobs",
+    "dispatch_loop",
+    "start_loops",
+    "stop_loops",
+]
+
+
+def start_loops() -> List[asyncio.Task]:
+    """Start all background loops and return the created tasks."""
+    try:
+        import main  # type: ignore
+        broadcast_enabled = getattr(main, "BROADCAST_ENABLED", BROADCAST_ENABLED)
+    except Exception:  # pragma: no cover - import fallback
+        broadcast_enabled = BROADCAST_ENABLED
+
+    tasks: List[asyncio.Task] = []
+    if broadcast_enabled:
+        tasks.append(asyncio.create_task(broadcast_presence()))
+    tasks.append(asyncio.create_task(poll_hashes_jobs()))
+    tasks.append(asyncio.create_task(process_hashes_jobs()))
+    tasks.append(asyncio.create_task(dispatch_loop()))
+    return tasks
+
+
+async def stop_loops(tasks: Iterable[asyncio.Task]) -> None:
+    """Cancel running tasks and wait for them to finish."""
+    for t in tasks:
+        t.cancel()
+    await asyncio.gather(*tasks, return_exceptions=True)

--- a/Server/app/background/broadcast.py
+++ b/Server/app/background/broadcast.py
@@ -1,0 +1,21 @@
+import asyncio
+import json
+import socket
+from utils.event_logger import log_error
+from app.config import CONFIG, BROADCAST_PORT, BROADCAST_INTERVAL
+
+
+async def broadcast_presence() -> None:
+    """Periodically broadcast the server URL over UDP."""
+    base = CONFIG.get("server_url", "http://localhost")
+    port = CONFIG.get("server_port", 8000)
+    url = f"{base}:{port}"
+    payload = json.dumps({"server_url": url}).encode()
+    while True:
+        try:
+            with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+                s.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+                s.sendto(payload, ("255.255.255.255", BROADCAST_PORT))
+        except Exception as e:  # pragma: no cover - network errors rarely tested
+            log_error("server", "system", "S716", "Broadcast failed", e)
+        await asyncio.sleep(BROADCAST_INTERVAL)

--- a/Server/app/background/dispatch.py
+++ b/Server/app/background/dispatch.py
@@ -1,0 +1,16 @@
+import asyncio
+import redis
+from utils.event_logger import log_error
+import orchestrator_agent
+
+
+async def dispatch_loop() -> None:
+    """Periodically dispatch queued batches to workers."""
+    while True:
+        try:
+            orchestrator_agent.dispatch_batches()
+        except redis.exceptions.RedisError as e:
+            log_error("server", "system", "SRED", "Redis unavailable", e)
+        except Exception as e:  # pragma: no cover - network errors rarely tested
+            log_error("server", "system", "S743", "Dispatch loop failed", e)
+        await asyncio.sleep(5)

--- a/Server/app/background/hashes_jobs.py
+++ b/Server/app/background/hashes_jobs.py
@@ -1,0 +1,138 @@
+import asyncio
+import json
+import os
+import redis
+
+from utils import redis_manager
+from utils.event_logger import log_error
+from app.config import (
+    HASHES_SETTINGS,
+    HASHES_POLL_INTERVAL,
+    HASHES_ALGORITHMS,
+    HASHES_DEFAULT_PRIORITY,
+    PREDEFINED_MASKS,
+    HASHES_ALGO_PARAMS,
+)
+
+
+async def fetch_and_store_jobs() -> None:
+    """Fetch jobs from hashes.com and store filtered results in Redis."""
+    try:
+        from hashescom_client import fetch_jobs
+        import main  # late import for patched r in tests
+
+        r = main.r
+        hashes_algorithms = getattr(main, "HASHES_ALGORITHMS", HASHES_ALGORITHMS)
+        jobs = await fetch_jobs()
+        for job in jobs:
+            algo = str(job.get("algorithmName", "")).lower()
+            if hashes_algorithms and algo not in hashes_algorithms:
+                continue
+            if job.get("currency") != "BTC":
+                continue
+            try:
+                price = float(job.get("pricePerHash", 0))
+            except (TypeError, ValueError):
+                price = 0.0
+            if price <= 0:
+                continue
+            job_id = job.get("id")
+            if job_id is not None:
+                r.hset(f"hashes_job:{job_id}", mapping=job)
+    except Exception as e:  # pragma: no cover - network errors rarely tested
+        log_error("server", "system", "S741", "Hashes.com fetch failed", e)
+
+
+async def poll_hashes_jobs() -> None:
+    """Background loop to periodically poll hashes.com for jobs."""
+    while True:
+        await fetch_and_store_jobs()
+        import main
+        settings = getattr(main, "HASHES_SETTINGS", HASHES_SETTINGS)
+        interval = int(settings.get("hashes_poll_interval", HASHES_POLL_INTERVAL))
+        await asyncio.sleep(interval)
+
+
+async def process_hashes_jobs() -> None:
+    """Queue batches for jobs fetched from hashes.com."""
+    import main  # late import for patched r and verify_hash in tests
+
+    r = main.r
+    verify_hash = main.verify_hash
+    algo_params = getattr(main, "HASHES_ALGO_PARAMS", HASHES_ALGO_PARAMS)
+    predefined_masks = getattr(main, "PREDEFINED_MASKS", PREDEFINED_MASKS)
+    default_priority = getattr(main, "HASHES_DEFAULT_PRIORITY", HASHES_DEFAULT_PRIORITY)
+
+    while True:
+        try:
+            for key in r.scan_iter("hashes_job:*"):
+                job = r.hgetall(key)
+                if job.get("status") == "processed":
+                    continue
+
+                try:
+                    hashes = json.loads(job.get("hashes", "[]"))
+                except Exception:
+                    hashes = []
+
+                algorithm = job.get("algorithmName", "")
+                algo_id = job.get("algorithmId")
+
+                known: list[str] = []
+                remaining: list[str] = []
+                for h in hashes:
+                    pw = r.hget("found:map", h)
+                    if pw and verify_hash(pw, h, algorithm):
+                        known.append(f"{h}:{pw}")
+                    else:
+                        remaining.append(h)
+
+                mask = job.get("mask", "")
+                wordlist = job.get("wordlist", "")
+                params = algo_params.get(algorithm.lower(), {})
+                mask_len = params.get("mask_length")
+                if mask_len:
+                    mask_len = int(mask_len)
+                    if mask:
+                        mask = mask[:mask_len]
+                    else:
+                        mask = "?a" * mask_len
+                rule = params.get("rule", "")
+                if known:
+                    try:
+                        import tempfile
+                        from hashescom_client import upload_founds
+
+                        with tempfile.NamedTemporaryFile("w", delete=False) as fh:
+                            fh.write("\n".join(known))
+                            temp_path = fh.name
+                        upload_founds(algo_id, temp_path)
+                        os.unlink(temp_path)
+                    except Exception:
+                        pass
+
+                batch_id = None
+                if remaining:
+                    priority = int(job.get("priority", default_priority))
+                    batch_id = redis_manager.store_batch(
+                        remaining,
+                        mask=mask,
+                        wordlist=wordlist,
+                        rule=rule,
+                        priority=priority,
+                    )
+                    for pm in predefined_masks:
+                        redis_manager.store_batch(
+                            remaining,
+                            mask=pm,
+                            wordlist=wordlist,
+                            rule=rule,
+                            priority=priority + 1,
+                        )
+                r.hset(key, mapping={"status": "processed", "batch_id": batch_id or ""})
+        except redis.exceptions.RedisError as e:
+            log_error("server", "system", "SRED", "Redis unavailable", e)
+        except Exception as e:
+            log_error("server", "system", "S742", "Failed to process hashes jobs", e)
+
+        await asyncio.sleep(30)

--- a/tests/test_shutdown_tasks.py
+++ b/tests/test_shutdown_tasks.py
@@ -33,10 +33,15 @@ async def test_tasks_cancelled_on_shutdown(monkeypatch):
                 raise
         return stub
 
-    monkeypatch.setattr(main, 'broadcast_presence', make_stub('bcast'))
-    monkeypatch.setattr(main, 'poll_hashes_jobs', make_stub('poll'))
-    monkeypatch.setattr(main, 'process_hashes_jobs', make_stub('process'))
-    monkeypatch.setattr(main, 'dispatch_loop', make_stub('dispatch'))
+    def fake_start_loops():
+        return [
+            asyncio.create_task(make_stub("bcast")()),
+            asyncio.create_task(make_stub("poll")()),
+            asyncio.create_task(make_stub("process")()),
+            asyncio.create_task(make_stub("dispatch")()),
+        ]
+
+    monkeypatch.setattr(main, 'start_loops', fake_start_loops)
     monkeypatch.setattr(main, 'print_logo', lambda: None)
     monkeypatch.setattr(main, 'BROADCAST_ENABLED', True)
 


### PR DESCRIPTION
## Summary
- move background loops to new `Server/app/background` modules
- start/stop loops through `app.background.start_loops` and `stop_loops`
- adjust `main` to use the new helpers
- update shutdown tasks test for the refactor

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68852cd23c8c83269290e9e4f98c37fa