### PR TITLE
Use root flake8 config

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -16,6 +16,6 @@ jobs:
       - name: Install dependencies
         run: pip install -r Server/requirements.txt -r Worker/requirements.txt -r Server/requirements-dev.txt
       - name: Run flake8
-        run: flake8 .
+        run: flake8 --config .flake8 .
       - name: Run tests
         run: pytest -q


### PR DESCRIPTION
## Summary
- place flake8 config in repo root so workflow can locate it
- point workflow to the config when running flake8

## Testing
- `flake8 --config .flake8 .` *(fails: F401 etc.)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68854514cd8c8326af04aa5bf82d62b9