### PR TITLE
Refactor server request models

### DIFF
--- a/Server/app/api/__init__.py
+++ b/Server/app/api/__init__.py
@@ -1,0 +1,1 @@
+"""API models and helpers."""

--- a/Server/app/api/models.py
+++ b/Server/app/api/models.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+from typing import Any
+from pydantic import BaseModel
+
+class LoginRequest(BaseModel):
+    passkey: str
+    username: str | None = None
+    password: str | None = None
+
+class LogoutRequest(BaseModel):
+    token: str
+
+class RegisterWorkerRequest(BaseModel):
+    worker_id: str
+    timestamp: int
+    signature: str
+    pubkey: str
+    mode: str = "eco"
+    provider: str = "on-prem"
+    hardware: dict = {}
+
+class WorkerStatusRequest(BaseModel):
+    name: str
+    status: str
+    timestamp: int
+    signature: str
+    temps: list[int] | None = None
+    progress: dict | None = None
+
+class SubmitHashrateRequest(BaseModel):
+    worker_id: str
+    gpu_uuid: str | None = None
+    hashrate: float
+    timestamp: int
+    signature: str
+
+class SubmitBenchmarkRequest(BaseModel):
+    worker_id: str
+    gpu_uuid: str
+    engine: str
+    hashrates: dict[str, float]
+    timestamp: int
+    signature: str
+
+class FlashResult(BaseModel):
+    worker_id: str
+    gpu_uuid: str
+    success: bool
+    timestamp: int
+    signature: str
+
+class SubmitFoundsRequest(BaseModel):
+    worker_id: str
+    batch_id: str
+    founds: list[str]
+    timestamp: int
+    signature: str
+    job_id: str | None = None
+    msg_id: str | None = None
+
+class SubmitNoFoundsRequest(BaseModel):
+    worker_id: str
+    batch_id: str
+    timestamp: int
+    signature: str
+    job_id: str | None = None
+    msg_id: str | None = None
+
+class TrainMarkovRequest(BaseModel):
+    lang: str = "english"
+    directory: str | None = None
+
+class TrainLLMRequest(BaseModel):
+    dataset: str
+    base_model: str
+    epochs: int
+    learning_rate: float
+    output_dir: str
+
+class ApiKeyRequest(BaseModel):
+    api_key: str
+
+class AlgoRequest(BaseModel):
+    algorithms: list[str]
+
+class AlgoParamsRequest(BaseModel):
+    algo: str
+    params: dict[str, Any]
+
+class HashesSettingsRequest(BaseModel):
+    hashes_poll_interval: int | None = None
+    algo_params: dict[str, dict[str, Any]] | None = None
+
+class JobPriorityRequest(BaseModel):
+    job_id: str
+    priority: int
+
+class JobConfigRequest(BaseModel):
+    job_id: str
+    priority: int
+
+class MaskListRequest(BaseModel):
+    masks: list[str]
+
+class ProbOrderRequest(BaseModel):
+    enabled: bool
+
+class InverseOrderRequest(BaseModel):
+    enabled: bool
+
+class MarkovLangRequest(BaseModel):
+    lang: str
+

--- a/tests/test_server_found_map.py
+++ b/tests/test_server_found_map.py
@@ -40,13 +40,19 @@ class FakeRedis:
 
 
 async def call():
-    payload = {
-        "worker_id": "w",
-        "batch_id": "b",
-        "founds": ["h1:p1", "h2:p2"],
-        "timestamp": 0,
-        "signature": "s",
-    }
+    payload = type(
+        "Req",
+        (),
+        {
+            "worker_id": "w",
+            "batch_id": "b",
+            "founds": ["h1:p1", "h2:p2"],
+            "timestamp": 0,
+            "signature": "s",
+            "job_id": None,
+            "msg_id": None,
+        },
+    )()
     return await main.submit_founds(payload)
 
 
@@ -85,13 +91,19 @@ def test_submit_founds_thread_safe(monkeypatch):
     for i in range(5):
         line = f"h{i}:p{i}"
         lines.append(line)
-        payload = {
-            "worker_id": f"w{i}",
-            "batch_id": f"b{i}",
-            "founds": [line],
-            "timestamp": 0,
-            "signature": "s",
-        }
+        payload = type(
+            "Req",
+            (),
+            {
+                "worker_id": f"w{i}",
+                "batch_id": f"b{i}",
+                "founds": [line],
+                "timestamp": 0,
+                "signature": "s",
+                "job_id": None,
+                "msg_id": None,
+            },
+        )()
         t = threading.Thread(target=_thread_call, args=(payload,))
         threads.append(t)
         t.start()

--- a/tests/test_server_get_batch.py
+++ b/tests/test_server_get_batch.py
@@ -81,14 +81,18 @@ def test_get_batch_returns_batch_id(monkeypatch):
     assert fake.read_args[0] == main.HTTP_GROUP
     assert list(fake.read_args[1].keys())[0] == main.JOB_STREAM
 
-    payload = {
-        "worker_id": "worker",
-        "batch_id": resp["batch_id"],
-        "job_id": resp["job_id"],
-        "msg_id": resp["msg_id"],
-        "timestamp": 0,
-        "signature": "sig",
-    }
+    payload = type(
+        "Req",
+        (),
+        {
+            "worker_id": "worker",
+            "batch_id": resp["batch_id"],
+            "job_id": resp["job_id"],
+            "msg_id": resp["msg_id"],
+            "timestamp": 0,
+            "signature": "sig",
+        },
+    )()
     monkeypatch.setattr(main, "verify_signature", lambda *a: True)
     asyncio.run(main.submit_no_founds(payload))
     assert fake.ack_args == (main.JOB_STREAM, main.HTTP_GROUP, "1-0")


### PR DESCRIPTION
## Summary
- centralize FastAPI request models under `Server/app/api/models.py`
- use typed models for `submit_founds` and `submit_no_founds`
- update tests to create request objects
- install missing dependencies for test run

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68854aca93b48326babd11a163428799