### PR TITLE
Remove outdated flake8 config

### DIFF
--- a/Server/setup.cfg
+++ b/Server/setup.cfg
@@ -1,3 +1,0 @@
-[flake8]
-max-line-length = 88
-extend-ignore = E203


### PR DESCRIPTION
## Summary
- remove redundant `[flake8]` section from `Server/setup.cfg`

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885525bc654832687b4f3d25a399cdb