### PR TITLE
Update tests for new app module paths

### DIFF
--- a/tests/test_allowed_origins.py
+++ b/tests/test_allowed_origins.py
@@ -38,12 +38,14 @@ def test_allowed_origins_applied(monkeypatch, tmp_path):
     cfg.write_text(json.dumps({"allowed_origins": ["https://foo"]}))
     monkeypatch.setenv('HOME', str(tmp_path))
 
-    import main
-    importlib.reload(main)
+    from Server.app import config, app
+    import importlib
+    importlib.reload(config)
+    importlib.reload(app)
 
-    app = main.app
+    app_instance = app.app
     found = False
-    for args, kw in app.added:
+    for args, kw in app_instance.added:
         if args and args[0] is cors_stub.CORSMiddleware:
             found = kw.get('allow_origins') == ["https://foo"]
     assert found

--- a/tests/test_auth_middleware.py
+++ b/tests/test_auth_middleware.py
@@ -19,7 +19,8 @@ install_stubs()
 
 
 
-import main
+from Server.app import app as app_mod
+import Server.main as main
 
 
 class FakeRedis:
@@ -86,7 +87,7 @@ def test_portal_auth_denies_without_key(monkeypatch):
         events.append(evt)
 
     app = FakeApp()
-    mw = main.PortalAuthMiddleware(app, key="secret")
+    mw = app_mod.PortalAuthMiddleware(app, key="secret")
     scope = {"type": "http", "path": "/portal", "headers": [(b"x-api-key", b"bad")]} 
 
     asyncio.run(mw(scope, lambda: None, send))
@@ -120,7 +121,7 @@ def test_logout_revokes_session(monkeypatch):
         events.append(evt)
 
     app = FakeApp()
-    mw = main.PortalAuthMiddleware(app, key="apikey")
+    mw = app_mod.PortalAuthMiddleware(app, key="apikey")
     scope = {
         "type": "http",
         "path": "/portal",
@@ -140,7 +141,7 @@ def test_root_auth_denies_without_key(monkeypatch):
         events.append(evt)
 
     app = FakeApp()
-    mw = main.PortalAuthMiddleware(app, key="secret")
+    mw = app_mod.PortalAuthMiddleware(app, key="secret")
     scope = {"type": "http", "path": "/", "headers": []}
 
     asyncio.run(mw(scope, lambda: None, send))
@@ -156,7 +157,7 @@ def test_portal_auth_allows_with_key(monkeypatch):
         events.append(evt)
 
     app = FakeApp()
-    mw = main.PortalAuthMiddleware(app, key="secret")
+    mw = app_mod.PortalAuthMiddleware(app, key="secret")
     scope = {"type": "http", "path": "/portal", "headers": [(b"x-api-key", b"secret")]} 
 
     asyncio.run(mw(scope, lambda: None, send))
@@ -172,7 +173,7 @@ def test_root_auth_allows_with_key(monkeypatch):
         events.append(evt)
 
     app = FakeApp()
-    mw = main.PortalAuthMiddleware(app, key="secret")
+    mw = app_mod.PortalAuthMiddleware(app, key="secret")
     scope = {"type": "http", "path": "/", "headers": [(b"x-api-key", b"secret")]}
 
     asyncio.run(mw(scope, lambda: None, send))
@@ -279,7 +280,7 @@ def test_portal_auth_allows_cookie(monkeypatch):
         events.append(evt)
 
     app = FakeApp()
-    mw = main.PortalAuthMiddleware(app, key="apikey")
+    mw = app_mod.PortalAuthMiddleware(app, key="apikey")
     scope = {
         "type": "http",
         "path": "/portal",
@@ -312,7 +313,7 @@ def test_session_expiry(monkeypatch):
         events.append(evt)
 
     app = FakeApp()
-    mw = main.PortalAuthMiddleware(app, key="apikey")
+    mw = app_mod.PortalAuthMiddleware(app, key="apikey")
     scope = {
         "type": "http",
         "path": "/portal",

--- a/tests/test_dispatch_loop.py
+++ b/tests/test_dispatch_loop.py
@@ -17,7 +17,7 @@ install_stubs()
 
 # Add repo paths
 
-import main
+from Server.app.background.dispatch import dispatch_loop
 import orchestrator_agent
 from utils import redis_manager
 
@@ -62,7 +62,7 @@ def run_once():
         orig = asyncio.sleep
         try:
             asyncio.sleep = fake_sleep
-            await main.dispatch_loop()
+            await dispatch_loop()
         except StopAsyncIteration:
             pass
         finally:

--- a/tests/test_flash_queue.py
+++ b/tests/test_flash_queue.py
@@ -15,7 +15,7 @@ from tests.test_helpers import (
 install_stubs()
 
 
-import main
+import Server.main as main
 
 
 class FakeRedis:

--- a/tests/test_hash_algos.py
+++ b/tests/test_hash_algos.py
@@ -15,7 +15,7 @@ from tests.test_helpers import (
 install_stubs()
 
 
-import main
+import Server.main as main
 
 
 def test_hash_algos_endpoint():

--- a/tests/test_hashes_config.py
+++ b/tests/test_hashes_config.py
@@ -15,7 +15,7 @@ from tests.test_helpers import (
 install_stubs()
 
 
-import main
+import Server.main as main
 
 class FakeRedis:
     def __init__(self):

--- a/tests/test_hashes_poll.py
+++ b/tests/test_hashes_poll.py
@@ -14,7 +14,9 @@ from tests.test_helpers import (
 install_stubs()
 
 
-import main
+from Server.app.background.hashes_jobs import fetch_and_store_jobs
+import Server.main as main
+sys.modules['main'] = main
 import hashescom_client
 
 class FakeRedis:
@@ -26,7 +28,7 @@ class FakeRedis:
         return []
 
 async def run_once():
-    await main.fetch_and_store_jobs()
+    await fetch_and_store_jobs()
 
 def test_fetch_and_store_jobs(monkeypatch):
     fake = FakeRedis()

--- a/tests/test_hashes_settings.py
+++ b/tests/test_hashes_settings.py
@@ -16,7 +16,9 @@ from tests.test_helpers import (
 install_stubs()
 
 
-import main
+import Server.main as main
+sys.modules['main'] = main
+from Server.app.background import hashes_jobs
 
 
 @pytest.mark.asyncio
@@ -47,13 +49,13 @@ async def test_poll_hashes_jobs_uses_setting(monkeypatch):
     called = {}
     async def fake_fetch():
         called['fetch'] = True
-    monkeypatch.setattr(main, 'fetch_and_store_jobs', fake_fetch)
+    monkeypatch.setattr(hashes_jobs, 'fetch_and_store_jobs', fake_fetch)
 
     async def fake_sleep(t):
         called['sleep'] = t
         raise StopAsyncIteration
     monkeypatch.setattr(asyncio, 'sleep', fake_sleep)
     with pytest.raises(StopAsyncIteration):
-        await main.poll_hashes_jobs()
+        await hashes_jobs.poll_hashes_jobs()
     assert called.get('sleep') == 5
 

--- a/tests/test_import_hashes.py
+++ b/tests/test_import_hashes.py
@@ -17,7 +17,7 @@ install_stubs()
 
 
 
-import main
+import Server.main as main
 from utils import redis_manager
 
 class FakeUploadFile:

--- a/tests/test_predefined_masks.py
+++ b/tests/test_predefined_masks.py
@@ -15,7 +15,7 @@ from tests.test_helpers import (
 install_stubs()
 
 
-import main
+import Server.main as main
 
 
 def test_update_predefined_masks(monkeypatch):

--- a/tests/test_process_hashes_jobs.py
+++ b/tests/test_process_hashes_jobs.py
@@ -19,7 +19,9 @@ install_stubs()
 
 
 
-import main
+from Server.app.background.hashes_jobs import process_hashes_jobs
+import Server.main as main
+sys.modules['main'] = main
 from utils import redis_manager
 from uuid import UUID
 
@@ -81,7 +83,7 @@ async def run_once():
     asyncio_sleep = asyncio.sleep
     try:
         asyncio.sleep = fake_sleep
-        await main.process_hashes_jobs()
+        await process_hashes_jobs()
     except StopAsyncIteration:
         pass
     finally:

--- a/tests/test_server_filepaths.py
+++ b/tests/test_server_filepaths.py
@@ -18,7 +18,7 @@ install_stubs()
 
 
 
-import main
+import Server.main as main
 
 class FakeUploadFile:
     def __init__(self, name, data):

--- a/tests/test_server_found_map.py
+++ b/tests/test_server_found_map.py
@@ -17,7 +17,7 @@ from tests.test_helpers import (
 install_stubs()
 
 
-import main
+import Server.main as main
 from utils import redis_manager
 
 class FakeRedis:

--- a/tests/test_server_get_batch.py
+++ b/tests/test_server_get_batch.py
@@ -15,7 +15,7 @@ from tests.test_helpers import (
 install_stubs()
 
 
-import main
+import Server.main as main
 from utils import redis_manager
 
 

--- a/tests/test_server_import_hashes.py
+++ b/tests/test_server_import_hashes.py
@@ -18,7 +18,7 @@ install_stubs()
 
 
 
-import main
+import Server.main as main
 from utils import redis_manager
 from uuid import UUID
 

--- a/tests/test_server_llm.py
+++ b/tests/test_server_llm.py
@@ -17,7 +17,7 @@ install_stubs()
 
 
 
-import main
+import Server.main as main
 
 
 def test_train_llm_invokes_helper(monkeypatch, tmp_path):

--- a/tests/test_server_markov.py
+++ b/tests/test_server_markov.py
@@ -17,7 +17,7 @@ install_stubs()
 
 
 
-import main
+import Server.main as main
 
 class DummyRedis:
     def __init__(self):

--- a/tests/test_server_register.py
+++ b/tests/test_server_register.py
@@ -16,7 +16,7 @@ from tests.test_helpers import (
 install_stubs()
 
 
-import main
+import Server.main as main
 
 class FakeRedis:
     def __init__(self):

--- a/tests/test_server_status.py
+++ b/tests/test_server_status.py
@@ -26,7 +26,7 @@ psutil_stub.getloadavg = lambda: (1.0, 0.5, 0.25)
 sys.modules.setdefault("psutil", psutil_stub)
 
 
-import main
+import Server.main as main
 
 class DummyRedis:
     def scard(self, key):

--- a/tests/test_server_submit_benchmark.py
+++ b/tests/test_server_submit_benchmark.py
@@ -16,7 +16,7 @@ install_stubs()
 
 
 
-import main
+import Server.main as main
 
 class FakeRedis:
     def __init__(self):

--- a/tests/test_server_train_llm.py
+++ b/tests/test_server_train_llm.py
@@ -17,7 +17,7 @@ install_stubs()
 
 
 
-import main
+import Server.main as main
 
 
 def test_train_llm_invokes_helper(monkeypatch, tmp_path):

--- a/tests/test_shutdown_tasks.py
+++ b/tests/test_shutdown_tasks.py
@@ -16,7 +16,8 @@ from tests.test_helpers import (
 install_stubs()
 
 
-import main
+import Server.main as main
+sys.modules['main'] = main
 
 @pytest.mark.asyncio
 async def test_tasks_cancelled_on_shutdown(monkeypatch):

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -13,7 +13,7 @@ from tests.test_helpers import (
 
 install_stubs()
 
-import main
+import Server.main as main
 
 class FakeRedis:
     def __init__(self):

--- a/tests/test_wordlist_db.py
+++ b/tests/test_wordlist_db.py
@@ -19,7 +19,7 @@ from tests.test_helpers import (
 install_stubs()
 
 
-import main
+import Server.main as main
 import orchestrator_agent
 import wordlist_db
 


### PR DESCRIPTION
## Summary
- refactor tests to import server modules from `Server.app`
- patch background functions via new modules
- keep `main` available for runtime imports

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68855a5b7a748326a627e42820625c1b