### PR TITLE
Improve GPU telemetry detection

### DIFF
--- a/Server/app/api/models.py
+++ b/Server/app/api/models.py
@@ -25,6 +25,8 @@ class WorkerStatusRequest(BaseModel):
     timestamp: int
     signature: str
     temps: list[int] | None = None
+    power: list[float] | None = None
+    utilization: list[int] | None = None
     progress: dict | None = None
 
 class SubmitHashrateRequest(BaseModel):

--- a/Server/main.py
+++ b/Server/main.py
@@ -679,11 +679,23 @@ async def get_worker_stats(worker_id: str, token: str | None = None):
         if not info:
             raise HTTPException(status_code=404, detail="not found")
         temps = []
+        power = []
+        util = []
         if info.get("temps"):
             try:
                 temps = json.loads(info["temps"])
             except Exception:
                 temps = []
+        if info.get("power"):
+            try:
+                power = json.loads(info["power"])
+            except Exception:
+                power = []
+        if info.get("utilization"):
+            try:
+                util = json.loads(info["utilization"])
+            except Exception:
+                util = []
         hashrate = 0.0
         try:
             hashrate = float(info.get("hashrate", 0))
@@ -691,6 +703,8 @@ async def get_worker_stats(worker_id: str, token: str | None = None):
             hashrate = 0.0
         return {
             "temps": temps,
+            "power": power,
+            "utilization": util,
             "hashrate": hashrate,
             "status": info.get("status", "unknown"),
         }
@@ -734,9 +748,15 @@ async def set_worker_status(data: WorkerStatusRequest):
     try:
         mapping = {"status": status, "last_seen": int(time.time())}
         temps = getattr(data, "temps", None)
+        power = getattr(data, "power", None)
+        util = getattr(data, "utilization", None)
         progress = getattr(data, "progress", None)
         if temps is not None:
             mapping["temps"] = json.dumps(temps)
+        if power is not None:
+            mapping["power"] = json.dumps(power)
+        if util is not None:
+            mapping["utilization"] = json.dumps(util)
         if progress is not None:
             mapping["progress"] = json.dumps(progress)
         r.hset(f"worker:{name}", mapping=mapping)

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -32,12 +32,23 @@ def test_get_worker_stats(monkeypatch):
     monkeypatch.setitem(main.CONFIG, "watchdog_token", "tok")
     monkeypatch.setattr(main, "WATCHDOG_TOKEN", "tok")
 
-    fake.hset("worker:alpha", mapping={"status": "idle", "hashrate": "5.0", "temps": "[70]"})
+    fake.hset(
+        "worker:alpha",
+        mapping={
+            "status": "idle",
+            "hashrate": "5.0",
+            "temps": "[70]",
+            "power": "[120.5]",
+            "utilization": "[80]",
+        },
+    )
 
     data = asyncio.run(main.get_worker_stats("alpha", token="tok"))
     assert data["status"] == "idle"
     assert data["hashrate"] == 5.0
     assert data["temps"] == [70]
+    assert data["power"] == [120.5]
+    assert data["utilization"] == [80]
 
     with pytest.raises(main.HTTPException):
         asyncio.run(main.get_worker_stats("alpha", token="bad"))

--- a/tests/test_worker_agent.py
+++ b/tests/test_worker_agent.py
@@ -181,6 +181,8 @@ def test_benchmark_low_bw_gpu(monkeypatch):
     monkeypatch.setattr(worker_agent, "GPUFlashManager", DummyFlash)
 
     monkeypatch.setattr(worker_agent, "get_gpu_temps", lambda: [])
+    monkeypatch.setattr(worker_agent, "get_gpu_power", lambda: [])
+    monkeypatch.setattr(worker_agent, "get_gpu_utilization", lambda: [])
 
     def stop(_):
         raise KeyboardInterrupt()
@@ -267,6 +269,8 @@ def test_prob_order_from_server(monkeypatch):
     monkeypatch.setattr(worker_agent, "GPUFlashManager", DummyFlash)
 
     monkeypatch.setattr(worker_agent, "get_gpu_temps", lambda: [])
+    monkeypatch.setattr(worker_agent, "get_gpu_power", lambda: [])
+    monkeypatch.setattr(worker_agent, "get_gpu_utilization", lambda: [])
 
     def stop(_):
         raise KeyboardInterrupt()


### PR DESCRIPTION
## Summary
- expand `detect_gpus()` with a sysfs fallback for AMD/Intel
- capture power and utilization via `get_gpu_power()` and `get_gpu_utilization()`
- report telemetry in `/worker_status`
- track telemetry on the server
- update worker tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68857d2546cc8326bd34b762e418b18d