### PR TITLE
Add remote upgrade capability

### DIFF
--- a/tests/test_worker_agent.py
+++ b/tests/test_worker_agent.py
@@ -285,3 +285,19 @@ def test_prob_order_from_server(monkeypatch):
     assert captured["prob"] is True
     assert captured["lang"] == "spanish"
     assert captured["inv"] is True
+
+
+def test_check_worker_command(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        worker_agent.requests,
+        "get",
+        lambda url, params=None, timeout=5: DummyResp({"status": "ok", "command": "upgrade"}),
+    )
+    monkeypatch.setattr(worker_agent, "sign_message", lambda *a: "sig")
+    monkeypatch.setattr(worker_agent.subprocess, "run", lambda cmd, **k: calls.append(cmd))
+
+    worker_agent.check_worker_command("alpha")
+
+    assert any("setup.py" in c for c in calls[0])
+    assert any("systemctl" in c for c in calls[1])


### PR DESCRIPTION
## Summary
- allow the server to queue `upgrade` and `restart` commands for workers
- expose `/get_worker_command` endpoint for workers to poll
- worker agent polls for commands and runs upgrade/restart via systemd
- add tests for upgrade queueing and command processing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688587dbdf1083268da5fa0f95dc2cfb