### PR TITLE
Add HIP/OpenCL build tests and prebuilt engine download

### DIFF
--- a/Worker/README.md
+++ b/Worker/README.md
@@ -28,7 +28,9 @@ dependencies and configure the worker. This command now also installs and
 starts a `hashmancer-worker` systemd service so the worker launches
 automatically on boot. Passing `--server-ip` skips broadcast discovery.
 Use `python3 ../setup.py --upgrade` anytime to pull the latest code and
-update dependencies.
+update dependencies. If `DARKLING_ENGINE_URL` is set the setup script will
+fetch a prebuilt `darkling-engine` binary from the provided URL so a full
+toolchain isn't required on the worker.
 
 Minimal `redis.conf` for a password-protected TLS instance:
 

--- a/darkling/README.md
+++ b/darkling/README.md
@@ -108,3 +108,7 @@ cmake --build build
 specific platform.  The resulting static libraries `cuda_backend`,
 `hip_backend`, and `opencl_backend` expose a `launch_darkling` entry point for
 each vendor.
+
+Precompiled binaries are published with each release. Set the environment
+variable `DARKLING_ENGINE_URL` before running `setup.py` on a worker to
+automatically download a ready-to-use `darkling-engine`.

--- a/tests/test_prebuilt_download.py
+++ b/tests/test_prebuilt_download.py
@@ -1,0 +1,29 @@
+import os
+from pathlib import Path
+import importlib.util
+
+spec = importlib.util.spec_from_file_location("setup", Path(__file__).resolve().parents[1] / "setup.py")
+setup = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(setup)
+
+
+def test_download_prebuilt_engine(monkeypatch, tmp_path):
+    data = b'binary-data'
+
+    class Resp:
+        status_code = 200
+        content = data
+        def raise_for_status(self):
+            pass
+
+    monkeypatch.setenv('DARKLING_ENGINE_URL', 'http://example.com/engine')
+    monkeypatch.setattr(setup.requests, 'get', lambda *a, **k: Resp())
+    monkeypatch.setattr(setup, 'CONFIG_DIR', tmp_path)
+
+    dest = tmp_path / 'bin' / 'darkling-engine'
+    if dest.exists():
+        dest.unlink()
+
+    setup.download_prebuilt_engine()
+    assert dest.exists()
+    assert dest.read_bytes() == data


### PR DESCRIPTION
## Summary
- support downloading a prebuilt `darkling-engine` with the `DARKLING_ENGINE_URL` env var
- install it under `~/.hashmancer/bin` and add that folder to the worker service PATH
- mention the new feature in docs
- add CMake build test for HIP/OpenCL backends
- provide unit test for download helper

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68858e8545048326a0828acc8156fdf5