### PR TITLE
Add GPU-specific darkling tuning

### DIFF
--- a/Worker/README.md
+++ b/Worker/README.md
@@ -80,6 +80,22 @@ Two optional environment variables allow you to tweak how `hashcat` runs:
   when the darkling engine is used. This allows independent tuning of
   experimental kernels.
 
+Grid and block sizes for the darkling engine can also be set per GPU model in
+`~/.hashmancer/worker_config.json`.  Add a `darkling_tuning` object mapping
+model names to `grid` and `block` values.  The worker exports these as the
+`DARKLING_GRID` and `DARKLING_BLOCK` environment variables when launching
+`darkling-engine`.
+
+Example configuration:
+
+```json
+{
+  "darkling_tuning": {
+    "GeForce RTX 3060": {"grid": 256, "block": 256}
+  }
+}
+```
+
 Each detected GPU is assigned its own sidecar thread so multiple devices run in
 parallel.  Logging and watchdog tasks now execute in dedicated threads inside
 the sidecars to avoid blocking GPU kernels.

--- a/Worker/hashmancer_worker/gpu_sidecar.py
+++ b/Worker/hashmancer_worker/gpu_sidecar.py
@@ -330,6 +330,13 @@ class GPUSidecar(threading.Thread):
             ]
 
             env = os.environ.copy()
+            if engine == "darkling-engine":
+                grid = self.gpu.get("darkling_grid")
+                block = self.gpu.get("darkling_block")
+                if grid:
+                    env["DARKLING_GRID"] = str(grid)
+                if block:
+                    env["DARKLING_BLOCK"] = str(block)
             self._apply_power_limit(engine)
             proc = subprocess.Popen(
                 cmd,

--- a/darkling/darkling_host.cpp
+++ b/darkling/darkling_host.cpp
@@ -104,6 +104,17 @@ struct DarklingContext {
         if(env && std::string(env)=="0") return;
         int device = 0;
         cudaGetDevice(&device);
+
+        const char* grid_env = std::getenv("DARKLING_GRID");
+        const char* block_env = std::getenv("DARKLING_BLOCK");
+        if(grid_env || block_env) {
+            if(grid_env) grid.x = std::atoi(grid_env);
+            if(block_env) block.x = std::atoi(block_env);
+            apply_power_limit(device);
+            tuned = true;
+            return;
+        }
+
         cudaDeviceProp prop{};
         cudaGetDeviceProperties(&prop, device);
 


### PR DESCRIPTION
## Summary
- allow per-model darkling tuning in `worker_config.json`
- inject grid/block overrides when launching the engine
- check `DARKLING_GRID`/`DARKLING_BLOCK` before autotuning
- document configuration of darkling tuning options

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68869f520c9c8326bc8456a25f95d0ea