### PR TITLE
Add vendor-specific prebuilt engine download

### DIFF
--- a/Worker/README.md
+++ b/Worker/README.md
@@ -29,8 +29,9 @@ starts a `hashmancer-worker` systemd service so the worker launches
 automatically on boot. Passing `--server-ip` skips broadcast discovery.
 Use `python3 ../setup.py --upgrade` anytime to pull the latest code and
 update dependencies. If `DARKLING_ENGINE_URL` is set the setup script will
-fetch a prebuilt `darkling-engine` binary from the provided URL so a full
-toolchain isn't required on the worker.
+fetch a prebuilt `darkling-engine` binary from the provided URL. Set
+`DARKLING_GPU_BACKEND` to `cuda`, `hip`, or `opencl` so the matching vendor
+build is downloaded. A full toolchain isn't required on the worker.
 
 Minimal `redis.conf` for a password-protected TLS instance:
 

--- a/tests/test_prebuilt_download.py
+++ b/tests/test_prebuilt_download.py
@@ -17,7 +17,15 @@ def test_download_prebuilt_engine(monkeypatch, tmp_path):
             pass
 
     monkeypatch.setenv('DARKLING_ENGINE_URL', 'http://example.com/engine')
-    monkeypatch.setattr(setup.requests, 'get', lambda *a, **k: Resp())
+    monkeypatch.setenv('DARKLING_GPU_BACKEND', 'cuda')
+
+    urls = []
+
+    def fake_get(url, *args, **kwargs):
+        urls.append(url)
+        return Resp()
+
+    monkeypatch.setattr(setup.requests, 'get', fake_get)
     monkeypatch.setattr(setup, 'CONFIG_DIR', tmp_path)
 
     dest = tmp_path / 'bin' / 'darkling-engine'
@@ -27,3 +35,4 @@ def test_download_prebuilt_engine(monkeypatch, tmp_path):
     setup.download_prebuilt_engine()
     assert dest.exists()
     assert dest.read_bytes() == data
+    assert urls == ['http://example.com/engine-cuda']


### PR DESCRIPTION
## Summary
- support CUDA, HIP and OpenCL binaries in `setup.py`
- document how to use `DARKLING_ENGINE_URL` with `DARKLING_GPU_BACKEND`
- adjust prebuilt engine tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886acf2dd4c8326b9e23f4d2f3bc36b