### PR TITLE
Add worker monitoring alerts

### DIFF
--- a/Server/README.md
+++ b/Server/README.md
@@ -386,6 +386,24 @@ Specify a list of origins permitted for CORS requests by adding
 
 If omitted, all origins are accepted.
 
+### Worker monitoring and logs
+
+`/worker_status` automatically checks GPU temperatures, power usage and
+per-GPU crash counts against configurable thresholds. Add the fields below to
+`~/.hashmancer/server_config.json` to customize the limits:
+
+```json
+{
+  "temp_threshold": 90,
+  "power_threshold": 250,
+  "crash_threshold": 3
+}
+```
+
+When a value exceeds its threshold an error entry is written to Redis. Recent
+records can be viewed with `/logs` and you can filter by worker using the
+`worker` query parameter.
+
 ### Trusted worker keys
 
 Restrict worker registration to known public keys by listing SHA-256 fingerprints

--- a/Server/app/config.py
+++ b/Server/app/config.py
@@ -106,3 +106,8 @@ LLM_MODEL_PATH = CONFIG.get("llm_model_path", "")
 LLM_TRAIN_EPOCHS = int(CONFIG.get("llm_train_epochs", 1))
 LLM_TRAIN_LEARNING_RATE = float(CONFIG.get("llm_train_learning_rate", 0.0001))
 
+# thresholds for worker monitoring
+TEMP_THRESHOLD = int(CONFIG.get("temp_threshold", 90))
+POWER_THRESHOLD = float(CONFIG.get("power_threshold", 250.0))
+CRASH_THRESHOLD = int(CONFIG.get("crash_threshold", 3))
+

--- a/tests/test_worker_status_alerts.py
+++ b/tests/test_worker_status_alerts.py
@@ -1,0 +1,55 @@
+import asyncio
+
+from tests.test_helpers import (
+    fastapi_stub,
+    cors_stub,
+    resp_stub,
+    pydantic_stub,
+    install_stubs,
+    FakeApp,
+)
+
+install_stubs()
+
+import Server.main as main
+
+
+class FakeRedis:
+    def __init__(self):
+        self.store = {}
+
+    def hset(self, key, mapping=None, **kwargs):
+        self.store.setdefault(key, {}).update(mapping or kwargs)
+
+    def hget(self, key, field):
+        return self.store.get(key, {}).get(field)
+
+    def hgetall(self, key):
+        return dict(self.store.get(key, {}))
+
+
+def test_high_temp_triggers_alert(monkeypatch):
+    fake = FakeRedis()
+    monkeypatch.setattr(main, "r", fake)
+    monkeypatch.setattr(main, "verify_signature", lambda *a: True)
+    monkeypatch.setattr(main, "TEMP_THRESHOLD", 60)
+    events = []
+    monkeypatch.setattr(
+        main,
+        "log_error",
+        lambda *a, **k: events.append(a[2] if len(a) > 2 else None),
+    )
+
+    class Req:
+        name = "alpha"
+        status = "idle"
+        timestamp = 0
+        signature = "s"
+        temps = [70]
+        power = None
+        utilization = None
+        progress = None
+
+    resp = asyncio.run(main.set_worker_status(Req()))
+    assert resp["status"] == "ok"
+    assert "H001" in events


### PR DESCRIPTION
## Summary
- add configurable monitoring thresholds
- log temperature/power/crash alerts in `/worker_status`
- document monitoring thresholds and logs
- test high temperature alert

## Testing
- `pytest -q tests/test_worker_status_alerts.py`

------
https://chatgpt.com/codex/tasks/task_e_6887a32da03c832683167824791a24b8