### PR TITLE
Add docker-compose with server and worker services

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,21 @@ access, restrict the port to their IPs with firewall rules (`iptables` or
 `ufw`). It's best to place Redis behind a VPN or require TLS with client
 certificates when exposing it over the internet.
 
+## Docker Compose
+
+The repository includes a `docker-compose.yml` for running Redis, the server
+and a worker. Start everything with one command:
+
+```bash
+docker compose up --build
+```
+
+Additional workers can be launched using the scale flag:
+
+```bash
+docker compose up --scale worker=3
+```
+
 ## Tests
 
 The unit tests cover both the server and worker components. Install their

--- a/Worker/hashmancer_worker/gpu_sidecar.py
+++ b/Worker/hashmancer_worker/gpu_sidecar.py
@@ -641,7 +641,7 @@ def run_darkling_benchmark(gpu: dict) -> dict[str, float]:
         except Exception as e:
             log_error(
                 "sidecar",
-                self.worker_id,
+                gpu.get("uuid", ""),
                 "W005",
                 f"Benchmark failed for {gpu.get('uuid')} mode {mode}",
                 e,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+version: "3.8"
+
+services:
+  redis:
+    image: redis:7
+    volumes:
+      - redis-data:/data
+
+  server:
+    build: .
+    ports:
+      - "8000:8000"
+    depends_on:
+      - redis
+
+  worker:
+    image: hashmancer-worker:latest
+    volumes:
+      - ~/.hashmancer:/root/.hashmancer
+    depends_on:
+      - redis
+      - server
+
+volumes:
+  redis-data:


### PR DESCRIPTION
## Summary
- add a docker-compose.yml describing redis, server, and worker containers
- document compose commands in README
- fix flake8 error in GPU sidecar

## Testing
- `flake8 --config .flake8 .`
- `pytest -q` *(fails: 10 failed, 119 passed, 4 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6887ba0cd140832695784d4fae508e35