### PR TITLE
Enhance setup automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ under the batch ID and only uses the job ID to acknowledge the stream entry.
 * `hashmancer/worker` – HTTP-based worker with GPU sidecar threads
 
 Run `python3 setup.py` from the repository root to configure either a server or
-worker.  Use `--server` or `--worker` flags to skip the prompt.  A worker can
-also supply `--server-ip` to skip auto-discovery. After setup, run
-`python3 setup.py --upgrade` to pull the latest version and update dependencies.
-Both components generate their RSA signing keys automatically the first time
-they run if no key files are present.
+worker.  Use `--server` or `--worker` flags to skip the prompt, or pass both to
+install the services in one step.  A worker can also supply `--server-ip` to
+skip auto-discovery. After setup, run `python3 setup.py --upgrade` to pull the
+latest version and update dependencies. Both components generate their RSA
+signing keys automatically the first time they run if no key files are present.
 
 Workers can enable probabilistic candidate ordering using `--probabilistic-order`.
 Use `--inverse-prob-order` to iterate from least likely candidates first. The

--- a/hashmancer/server/README.md
+++ b/hashmancer/server/README.md
@@ -65,6 +65,12 @@ cd hashmancer-server
 python3 ../setup.py --server
 ```
 
+To configure a worker on the same machine in the same run use:
+
+```bash
+python3 ../setup.py --server --worker
+```
+
 Run `python3 ../setup.py --upgrade` later to pull updates and refresh
 dependencies.
 
@@ -86,13 +92,11 @@ uvicorn main:app --host 0.0.0.0 --port 8000
 
 ## 🔧 Systemd Service
 
-To install manually:
+`setup.py` automatically installs and starts the `hashmancer-server.service` for
+you. If you ever need to reinstall it manually run:
 
 ```bash
-sudo cp hashmancer-server.service /etc/systemd/system/
-sudo systemctl daemon-reexec
-sudo systemctl enable hashmancer-server
-sudo systemctl start hashmancer-server
+sudo systemctl enable --now hashmancer-server
 ```
 
 ---

--- a/hashmancer/server/setup.py
+++ b/hashmancer/server/setup.py
@@ -81,8 +81,13 @@ WantedBy=multi-user.target
 
     subprocess.run(["sudo", "mv", "/tmp/hashmancer-server.service", SERVICE_FILE])
     subprocess.run(["sudo", "systemctl", "daemon-reexec"])
-    subprocess.run(["sudo", "systemctl", "enable", "hashmancer-server.service"])
-    subprocess.run(["sudo", "systemctl", "start", "hashmancer-server.service"])
+    subprocess.run([
+        "sudo",
+        "systemctl",
+        "enable",
+        "--now",
+        "hashmancer-server.service",
+    ])
     print("✅ Systemd service installed and started.")
 
 

--- a/hashmancer/worker/README.md
+++ b/hashmancer/worker/README.md
@@ -25,9 +25,10 @@ heartbeat interval can be customized with `STATUS_INTERVAL` (seconds).
 ## Setup
 
 Run `python3 ../setup.py --worker` from the repository root to install
-dependencies and configure the worker. This command now also installs and
-starts a `hashmancer-worker` systemd service so the worker launches
-automatically on boot. Passing `--server-ip` skips broadcast discovery.
+dependencies and configure the worker. This command installs and starts a
+`hashmancer-worker` systemd service so the worker launches automatically on
+boot. You can combine `--server --worker` to set up both components at once.
+Passing `--server-ip` skips broadcast discovery.
 Use `python3 ../setup.py --upgrade` anytime to pull the latest code and
 update dependencies. If `DARKLING_ENGINE_URL` is set the setup script will
 fetch a prebuilt `darkling-engine` binary from the provided URL. Set

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,4 @@
+from manage import *
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- fix docs around setup.py usage
- add wrapper setup.py
- enable combined server/worker install
- auto-start services with systemctl

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'darkling')*

------
https://chatgpt.com/codex/tasks/task_e_6887cf1a99f4832693729ccab23eea23