### PR TITLE
Add worker Dockerfile and document configuration

### DIFF
--- a/Worker/Dockerfile
+++ b/Worker/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# install hashcat
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    hashcat \
+    && rm -rf /var/lib/apt/lists/*
+
+# copy worker package and install requirements
+COPY hashmancer /app/hashmancer
+COPY Worker/requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
+
+CMD ["python", "-m", "hashmancer.worker.hashmancer_worker.worker_agent"]

--- a/Worker/README.md
+++ b/Worker/README.md
@@ -1,0 +1,26 @@
+# Hashmancer Worker
+
+This directory contains Docker resources for running the worker component.
+
+## Environment variables
+
+The worker is configured entirely through environment variables:
+
+- `REDIS_HOST` – hostname for the Redis instance used for caching and logging.
+- `REDIS_PORT` – port for the Redis server (default `6379`).
+- `REDIS_PASSWORD` – optional password used when connecting to Redis.
+- `REDIS_SSL` – set to `1` to enable TLS. Use `REDIS_SSL_CA_CERT`,
+  `REDIS_SSL_CERT` and `REDIS_SSL_KEY` to provide certificate paths.
+- `SERVER_URL` – base URL of the Hashmancer server API.
+- `PRIVATE_KEY_PATH` – path to the worker's private RSA key.
+- `PUBLIC_KEY_PATH` – path to the worker's public key.
+- `STATUS_INTERVAL` – seconds between status heartbeats (default `30`).
+- `HASHCAT_WORKLOAD` – workload profile passed to `hashcat` via `-w`.
+- `HASHCAT_OPTIMIZED` – when set to `1`, adds `-O` to enable optimized kernels.
+- `GPU_POWER_LIMIT` – power limit applied before starting hashcat.
+- `DARKLING_GPU_POWER_LIMIT` – alternate power limit for the darkling engine.
+- `DARKLING_ENGINE_URL` – URL for downloading a prebuilt darkling engine.
+- `DARKLING_GPU_BACKEND` – choose `cuda`, `hip` or `opencl` for darkling.
+
+If the paths specified by `PRIVATE_KEY_PATH` and `PUBLIC_KEY_PATH` do not
+exist the worker generates a new 4096‑bit key pair on first run.

--- a/Worker/requirements.txt
+++ b/Worker/requirements.txt
@@ -1,0 +1,3 @@
+redis==6.2.0
+requests==2.32.4
+cryptography==45.0.5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,9 @@ services:
       - redis
 
   worker:
-    image: hashmancer-worker:latest
+    build:
+      context: .
+      dockerfile: Worker/Dockerfile
     volumes:
       - ~/.hashmancer:/root/.hashmancer
     depends_on:


### PR DESCRIPTION
## Summary
- add a new Dockerfile under `Worker/` that installs hashcat and the worker package
- build the worker container from this Dockerfile in `docker-compose.yml`
- document required worker environment variables in `Worker/README.md`

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'darkling')*

------
https://chatgpt.com/codex/tasks/task_e_6887e495f5388326949f987add21446b