### PR TITLE
Add installer helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,15 @@ skip auto-discovery. After setup, run `python3 setup.py --upgrade` to pull the
 latest version and update dependencies. Both components generate their RSA
 signing keys automatically the first time they run if no key files are present.
 
+You can also use the helper script `scripts/install_all.sh` for a non-
+interactive install:
+
+```bash
+./scripts/install_all.sh --server --worker
+```
+The script prints commands for starting the services once installation
+finishes.
+
 Workers can enable probabilistic candidate ordering using `--probabilistic-order`.
 Use `--inverse-prob-order` to iterate from least likely candidates first. The
 server portal exposes matching checkboxes under the Markov Training section.

--- a/scripts/install_all.sh
+++ b/scripts/install_all.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -e
+
+SERVER=false
+WORKER=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --server)
+      SERVER=true
+      ;;
+    --worker)
+      WORKER=true
+      ;;
+    *)
+      echo "Usage: $0 [--server] [--worker]"
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+if ! $SERVER && ! $WORKER; then
+  SERVER=true
+  WORKER=true
+fi
+
+if $SERVER; then
+  python3 setup.py --server
+fi
+
+if $WORKER; then
+  python3 setup.py --worker
+fi
+
+echo
+if $SERVER; then
+  echo "Server installed. Start it with systemd or run:"
+  echo "  uvicorn main:app --host 0.0.0.0 --port 8000"
+fi
+
+if $WORKER; then
+  echo "Worker installed. Launch it with:"
+  echo "  python -m hashmancer.worker.hashmancer_worker.worker_agent"
+fi


### PR DESCRIPTION
## Summary
- add `scripts/install_all.sh` to simplify running setup.py for server/worker installs
- reference the helper in the README

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q` *(fails: ModuleNotFoundError in several tests)*

------
https://chatgpt.com/codex/tasks/task_e_6887e8e3194883269fab907ecb35aeb5