### PR TITLE
Fix pytest collection for darkling import

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,13 @@ def _ensure_paths():
 
 _ensure_paths()
 
+import types
+from hashmancer.darkling import charsets
+
+darkling_mod = types.ModuleType("darkling")
+darkling_mod.charsets = charsets
+sys.modules.setdefault("darkling", darkling_mod)
+
 
 @pytest.fixture(scope="session", autouse=True)
 def add_repo_to_path():


### PR DESCRIPTION
## Summary
- ensure darkling package is on `sys.modules` when tests run

## Testing
- `pytest tests/test_charsets.py::test_common_symbols_length -q`

------
https://chatgpt.com/codex/tasks/task_e_6888004134948326b43a3dafea0602b6