### PR TITLE
Add orchestrator dispatch tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ import os
 import pytest
 
 REPO_ROOT = os.path.dirname(os.path.dirname(__file__))
-SERVER_PATH = os.path.join(REPO_ROOT, "Server")
+SERVER_PATH = os.path.join(REPO_ROOT, "hashmancer", "server")
 
 
 def _ensure_paths():
@@ -21,6 +21,25 @@ from hashmancer.darkling import charsets
 darkling_mod = types.ModuleType("darkling")
 darkling_mod.charsets = charsets
 sys.modules.setdefault("darkling", darkling_mod)
+
+import importlib
+orchestrator_mod = importlib.import_module("hashmancer.server.orchestrator_agent")
+sys.modules.setdefault("orchestrator_agent", orchestrator_mod)
+
+wordlist_mod = importlib.import_module("hashmancer.server.wordlist_db")
+sys.modules.setdefault("wordlist_db", wordlist_mod)
+
+utils_mod = importlib.import_module("hashmancer.utils")
+sys.modules.setdefault("utils", utils_mod)
+
+pattern_mod = importlib.import_module("hashmancer.server.pattern_to_mask")
+sys.modules.setdefault("pattern_to_mask", pattern_mod)
+
+hashescom_mod = importlib.import_module("hashmancer.server.hashescom_client")
+sys.modules.setdefault("hashescom_client", hashescom_mod)
+
+from hashmancer.darkling import statistics
+darkling_mod.statistics = statistics
 
 
 @pytest.fixture(scope="session", autouse=True)


### PR DESCRIPTION
## Summary
- test priority queueing order and backlog handling for `dispatch_batches`
- expose server helpers in test environment for imports

## Testing
- `pytest -q` *(fails: test_prebuilt_download, test_sign_message_cache, test_sign_message_generation)*

------
https://chatgpt.com/codex/tasks/task_e_6888070db4a88326b01fce9bcbdb6803