### PR TITLE
Fix CI requirements path and tests

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -16,7 +16,10 @@ jobs:
         with:
           python-version: '3.11'
       - name: Install dependencies
-        run: pip install -r Server/requirements.txt -r Worker/requirements.txt -r Server/requirements-dev.txt
+        run: |
+          pip install -r hashmancer/server/requirements.txt \
+                       -r hashmancer/worker/requirements.txt \
+                       -r hashmancer/server/requirements-dev.txt
       - name: Run flake8
         run: flake8 --config .flake8 .
       - name: Run tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,6 +38,9 @@ sys.modules.setdefault("pattern_to_mask", pattern_mod)
 hashescom_mod = importlib.import_module("hashmancer.server.hashescom_client")
 sys.modules.setdefault("hashescom_client", hashescom_mod)
 
+server_pkg = importlib.import_module("hashmancer.server")
+sys.modules.setdefault("Server", server_pkg)
+
 from hashmancer.darkling import statistics
 darkling_mod.statistics = statistics
 

--- a/tests/test_prebuilt_download.py
+++ b/tests/test_prebuilt_download.py
@@ -1,10 +1,6 @@
 import os
 from pathlib import Path
-import importlib.util
-
-spec = importlib.util.spec_from_file_location("setup", Path(__file__).resolve().parents[1] / "setup.py")
-setup = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(setup)
+import manage
 
 
 def test_download_prebuilt_engine(monkeypatch, tmp_path):
@@ -25,14 +21,14 @@ def test_download_prebuilt_engine(monkeypatch, tmp_path):
         urls.append(url)
         return Resp()
 
-    monkeypatch.setattr(setup.requests, 'get', fake_get)
-    monkeypatch.setattr(setup, 'CONFIG_DIR', tmp_path)
+    monkeypatch.setattr(manage.requests, 'get', fake_get)
+    monkeypatch.setattr(manage, 'CONFIG_DIR', tmp_path)
 
     dest = tmp_path / 'bin' / 'darkling-engine'
     if dest.exists():
         dest.unlink()
 
-    setup.download_prebuilt_engine()
+    manage.download_prebuilt_engine()
     assert dest.exists()
     assert dest.read_bytes() == data
     assert urls == ['http://example.com/engine-cuda']


### PR DESCRIPTION
## Summary
- fix dependency paths in Python workflow
- alias `Server` package for tests
- use `manage` module in `test_prebuilt_download`

## Testing
- `flake8 --config .flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887f27b58cc8326a60ba7b9e50207db