### PR TITLE
Fix GPU PCI field and flash preset handling

### DIFF
--- a/hashmancer/server/main.py
+++ b/hashmancer/server/main.py
@@ -236,7 +236,8 @@ else:
 def get_flash_settings(model: str) -> dict:
     name = model.lower()
     vendor = "nvidia"
-    if "amd" in name or "radeon" in name or "rx" in name:
+    # ignore "rtx" when searching for AMD's "rx" prefix
+    if "amd" in name or "radeon" in name or "rx" in name.replace("rtx", ""):
         vendor = "amd"
     presets = FLASH_PRESETS[vendor]
     for key, val in presets.items():

--- a/hashmancer/server/orchestrator_agent.py
+++ b/hashmancer/server/orchestrator_agent.py
@@ -124,7 +124,7 @@ def worker_counts():
 
 
 def gpu_metrics() -> list[tuple[int, float]]:
-    """Return a list of (pci_width, hashrate) tuples for each GPU."""
+    """Return a list of (pci_link_width, hashrate) tuples for each GPU."""
     metrics: list[tuple[int, float]] = []
     try:
         for key in r.scan_iter("gpu:*"):

--- a/hashmancer/worker/hashmancer_worker/gpu_sidecar.py
+++ b/hashmancer/worker/hashmancer_worker/gpu_sidecar.py
@@ -204,7 +204,7 @@ class GPUSidecar(threading.Thread):
 
         _safe_redis_call(r.hset, f"job:{job_id}", mapping=batch)
 
-        if self.gpu.get("pci_width", 16) <= 4:
+        if self.gpu.get("pci_link_width", 16) <= 4:
             _safe_redis_call(
                 r.hset,
                 f"vram:{self.gpu['uuid']}:{job_id}",
@@ -227,7 +227,7 @@ class GPUSidecar(threading.Thread):
             f"GPU {self.gpu['uuid']} processing {batch_id}",
         )
         if (
-            self.gpu.get("pci_link_width", self.gpu.get("pci_width", 16)) <= 4
+            self.gpu.get("pci_link_width", 16) <= 4
             and self.low_bw_engine == "darkling"
         ):
             founds = self.run_darkling_engine(batch)

--- a/tests/test_flash_settings.py
+++ b/tests/test_flash_settings.py
@@ -1,0 +1,14 @@
+import sys
+from tests.test_helpers import install_stubs
+install_stubs()
+import hashmancer.server.main as main
+
+
+def test_get_flash_settings_nvidia():
+    info = main.get_flash_settings("GeForce RTX 3080")
+    assert info["vendor"] == "nvidia"
+
+
+def test_get_flash_settings_amd():
+    info = main.get_flash_settings("Radeon RX 480")
+    assert info["vendor"] == "amd"


### PR DESCRIPTION
## Summary
- drop redundant Path import
- use only `pci_link_width` across worker, sidecar and orchestrator
- simplify sidecar creation call
- ensure `get_flash_settings` ignores `rtx` when testing for AMD models
- test AMD/NVIDIA flash preset detection

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688817b375d08326979dd6fc2bf4d208