### PR TITLE
Fix traceback handling in log_event

### DIFF
--- a/hashmancer/utils/event_logger.py
+++ b/hashmancer/utils/event_logger.py
@@ -46,8 +46,12 @@ def log_event(
         "level": level,
         "message": message,
     }
-    if details:
-        event["traceback"] = traceback.format_exc(limit=2)
+    if details is not None:
+        event["traceback"] = details
+    else:
+        tb = traceback.format_exc(limit=2)
+        if tb and tb != "NoneType: None\n":
+            event["traceback"] = tb
 
     try:
         if hasattr(r, "rpush"):

--- a/tests/test_event_logger.py
+++ b/tests/test_event_logger.py
@@ -1,0 +1,20 @@
+import json
+from hashmancer.utils import event_logger
+
+class FakeRedis:
+    def __init__(self):
+        self.data = []
+    def rpush(self, name, value):
+        self.data.append(value)
+    def ltrim(self, name, start, end):
+        pass
+
+def test_log_event_stores_provided_traceback(monkeypatch):
+    fake = FakeRedis()
+    monkeypatch.setattr(event_logger, "r", fake)
+    tb = "Traceback: something bad"
+    event_logger.log_event("w", "E1", "msg", level="error", details=tb)
+    assert fake.data, "no data pushed"
+    stored = json.loads(fake.data[0])
+    assert stored["traceback"] == tb
+


### PR DESCRIPTION
## Summary
- fix `log_event` to store provided traceback strings
- add regression test for `log_event`

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68881d573d508326ad8e729243f74ea5