### PR TITLE
Update dependencies and cleanup imports

### DIFF
--- a/hashmancer/darkling/statistics.py
+++ b/hashmancer/darkling/statistics.py
@@ -100,7 +100,6 @@ def probability_index_order(
     indices: List[int] = []
 
     def recurse(pos: int, prev: str):
-        nonlocal indices
         if limit is not None and len(indices) >= limit:
             return
         if pos == len(charsets_list):

--- a/hashmancer/server/app/background/__init__.py
+++ b/hashmancer/server/app/background/__init__.py
@@ -25,7 +25,7 @@ __all__ = [
 def start_loops() -> List[asyncio.Task]:
     """Start all background loops and return the created tasks."""
     try:
-        import main  # type: ignore
+        from hashmancer.server import main  # type: ignore
         broadcast_enabled = getattr(main, "BROADCAST_ENABLED", BROADCAST_ENABLED)
     except Exception:  # pragma: no cover - import fallback
         broadcast_enabled = BROADCAST_ENABLED

--- a/hashmancer/server/app/background/watchdog.py
+++ b/hashmancer/server/app/background/watchdog.py
@@ -12,7 +12,7 @@ async def watchdog_loop() -> None:
     """Check worker heartbeats and mark stale workers offline."""
     while True:
         try:
-            import main  # late import so tests can patch 'r'
+            from hashmancer.server import main  # late import so tests can patch 'r'
             r = main.r
             now = int(time.time())
             threshold = 5 * STATUS_INTERVAL

--- a/hashmancer/server/auth_utils.py
+++ b/hashmancer/server/auth_utils.py
@@ -1,5 +1,4 @@
 import base64
-import redis
 from .redis_utils import get_redis
 import logging
 import time

--- a/hashmancer/server/hashescom_client.py
+++ b/hashmancer/server/hashescom_client.py
@@ -1,7 +1,6 @@
 import asyncio
 import os
 import json
-from pathlib import Path
 import logging
 
 import requests

--- a/hashmancer/server/orchestrator_agent.py
+++ b/hashmancer/server/orchestrator_agent.py
@@ -5,7 +5,6 @@ import time
 import uuid
 import redis
 import base64
-import gzip
 import zlib
 import hashlib
 import re

--- a/hashmancer/server/restore_manager.py
+++ b/hashmancer/server/restore_manager.py
@@ -1,5 +1,4 @@
 import os
-import glob
 import shutil
 import logging
 from pathlib import Path

--- a/hashmancer/server/wordlist_db.py
+++ b/hashmancer/server/wordlist_db.py
@@ -1,7 +1,5 @@
-import os
 import sqlite3
-from pathlib import Path
-from typing import Iterable, Generator
+from typing import Generator
 
 from .app.config import WORDLIST_DB_PATH
 

--- a/hashmancer/worker/hashmancer_worker/gpu_sidecar.py
+++ b/hashmancer/worker/hashmancer_worker/gpu_sidecar.py
@@ -2,7 +2,6 @@ import os
 import time
 import threading
 import redis
-import logging
 from hashmancer.utils.event_logger import log_error, log_info
 
 try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,18 @@ name = "hashmancer"
 version = "0.1.0"
 readme = "README.md"
 requires-python = ">=3.10"
-dependencies = []
+dependencies = [
+    "fastapi==0.116.1",
+    "uvicorn==0.35.0",
+    "redis==6.2.0",
+    "requests==2.32.4",
+    "pydantic==2.11.7",
+    "cryptography==45.0.5",
+    "python-multipart==0.0.20",
+    "psutil==7.0.0",
+    "filelock==3.18.0",
+    "argon2-cffi==25.1.0",
+]
 
 [project.scripts]
 hashmancer-server = "hashmancer.server.__main__:main"

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,18 @@
 """Entry module exposing helper functions for installation scripts."""
 
-from manage import main
 from pathlib import Path
+
+try:
+    from manage import main  # type: ignore
+except Exception:  # pragma: no cover - fallback when not on path
+    def main() -> None:  # type: ignore
+        raise RuntimeError("manage script unavailable")
 import os
 import shutil
-import requests
+try:
+    import requests
+except Exception:  # pragma: no cover - optional during build
+    requests = None  # type: ignore
 
 CONFIG_DIR = Path.home() / ".hashmancer"
 
@@ -47,5 +55,3 @@ def download_prebuilt_engine() -> None:
     except Exception as e:
         print(f"⚠️  Failed to download prebuilt engine: {e}")
 
-if __name__ == "__main__":
-    main()

--- a/tests/test_set_hashes_api_key.py
+++ b/tests/test_set_hashes_api_key.py
@@ -1,0 +1,23 @@
+import asyncio
+import importlib
+import sys
+
+import hashmancer.server.main as main
+
+async def _call(monkeypatch):
+    monkeypatch.setattr(main, "CONFIG", {})
+    monkeypatch.setattr(main, "save_config", lambda: None)
+    called = {}
+    def fake_reload(mod):
+        called["module"] = mod
+        return mod
+    monkeypatch.setattr(importlib, "reload", fake_reload)
+    req = type("Req", (), {"api_key": "abc"})()
+    await main.set_hashes_api_key(req)
+    return called
+
+
+def test_set_hashes_api_key_reload(monkeypatch):
+    called = asyncio.run(_call(monkeypatch))
+    assert called["module"] is sys.modules["hashmancer.server.hashescom_client"]
+


### PR DESCRIPTION
## Summary
- add project dependencies
- qualify imports for background tasks
- reload hashescom_client in `set_hashes_api_key`
- add reload unit test
- drop unused imports and fix packaging script

## Testing
- `pyflakes hashmancer`
- `flake8`
- `python setup.py --version`

------
https://chatgpt.com/codex/tasks/task_e_68881f53fab0832683f3b5ee592f34c2