### PR TITLE
Improve server error handling

### DIFF
--- a/hashmancer/server/README.md
+++ b/hashmancer/server/README.md
@@ -183,6 +183,13 @@ performance over time.
 
 ---
 
+### Failure responses
+
+Redis errors return `500` with `{\"detail\": \"redis unavailable\"}`.
+Filesystem failures return `{\"detail\": \"filesystem error\"}`.
+
+---
+
 ### CSV format for `/import_hashes`
 
 Upload a CSV containing the following columns:

--- a/hashmancer/server/app/background/hashes_jobs.py
+++ b/hashmancer/server/app/background/hashes_jobs.py
@@ -18,7 +18,7 @@ from ..config import (
 async def fetch_and_store_jobs() -> None:
     """Fetch jobs from hashes.com and store filtered results in Redis."""
     try:
-        from hashmancer.server import hashescom_client
+        import hashescom_client
         from hashmancer.server import main  # late import for patched r in tests
 
         r = main.r
@@ -101,7 +101,7 @@ async def process_hashes_jobs() -> None:
                 if known:
                     try:
                         import tempfile
-                        from hashmancer.server import hashescom_client
+                        import hashescom_client
 
                         with tempfile.NamedTemporaryFile("w", delete=False) as fh:
                             fh.write("\n".join(known))

--- a/tests/test_auth_middleware.py
+++ b/tests/test_auth_middleware.py
@@ -61,6 +61,9 @@ class FakeRedis:
         if ex:
             self.store[f"ttl:{key}"] = ex
 
+    def ttl(self, key):
+        return self.store.get(f"ttl:{key}", -1)
+
     def exists(self, key):
         return key in self.store
 
@@ -235,12 +238,15 @@ def test_initial_login_requires_credentials(monkeypatch):
     monkeypatch.setattr(main, "r", fake_r)
     monkeypatch.setitem(main.CONFIG, "initial_admin_token", "token")
     monkeypatch.setattr(main, "PORTAL_PASSKEY", "pass")
+    logged = {}
+    monkeypatch.setattr(main, "log_error", lambda *a, **k: logged.setdefault("err", True))
 
     class Req:
         passkey = "token"
 
     with pytest.raises(main.HTTPException):
         asyncio.run(main.login(Req()))
+    assert logged.get("err")
 
 
 def test_initial_login_sets_credentials(monkeypatch):


### PR DESCRIPTION
## Summary
- validate request payloads with pydantic validators
- add more explicit exception handling in main.py
- log logout failures and invalid worker status updates
- use environment startup hook
- check mask length before dispatch
- document error responses
- extend tests for new error paths

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688828911aec8326a0ac1781cd6224df