### PR TITLE
Fix flash tuner presets path

### DIFF
--- a/hashmancer/worker/hashmancer_worker/flash_tuner.py
+++ b/hashmancer/worker/hashmancer_worker/flash_tuner.py
@@ -4,7 +4,12 @@ from pathlib import Path
 
 from .bios_flasher import apply_flash_settings, md5_speed
 
-PRESETS_FILE = Path(__file__).resolve().parents[2] / "Server" / "flash_presets.json"
+PRESETS_FILE = (
+    Path(__file__).resolve().parents[2]
+    / "hashmancer"
+    / "server"
+    / "flash_presets.json"
+)
 
 
 def load_presets() -> dict:


### PR DESCRIPTION
## Summary
- update flash tuner presets file path to use new server location

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888daae532483269d5cab379c1a5632