### PR TITLE
Fix Dockerfile paths

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,11 +15,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY . /app
 
 # Install Python dependencies for the server
-RUN pip install --no-cache-dir -r Server/requirements.txt
+RUN pip install --no-cache-dir -r hashmancer/server/requirements.txt
 
 # Expose the default uvicorn port
 EXPOSE 8000
 
 # Run the FastAPI server
-WORKDIR /app/Server
+WORKDIR /app/hashmancer/server
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
- install server deps from `hashmancer/server/requirements.txt`
- set server workdir to `/app/hashmancer/server`

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888e34fc3008326a22060af7fdf9ce7