### PR TITLE
Fix flash tuner preset path

### DIFF
--- a/hashmancer/worker/hashmancer_worker/flash_tuner.py
+++ b/hashmancer/worker/hashmancer_worker/flash_tuner.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from .bios_flasher import apply_flash_settings, md5_speed
 
 PRESETS_FILE = (
-    Path(__file__).resolve().parents[2]
+    Path(__file__).resolve().parents[3]
     / "hashmancer"
     / "server"
     / "flash_presets.json"


### PR DESCRIPTION
## Summary
- correct preset file path to load from server folder

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68890a3eba6883269760b08d5f353c57