### PR TITLE
Remove outdated comment from pattern utils test

### DIFF
--- a/tests/test_pattern_utils.py
+++ b/tests/test_pattern_utils.py
@@ -2,8 +2,6 @@ import os
 import sys
 import pytest
 
-# Allow importing the Server package from the repository root
-
 from hashmancer.server.pattern_utils import word_to_pattern, is_valid_pattern, is_valid_word
 
 


### PR DESCRIPTION
## Summary
- clean up `tests/test_pattern_utils.py`
- remove reference to nonexistent Server package

## Testing
- `flake8 --config .flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68890ce8d888832688aacaaade3b7b34