### PR TITLE
Clean Docker worker requirements

### DIFF
--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # copy worker package and install requirements
 COPY hashmancer /app/hashmancer
-COPY docker/worker/requirements.txt /tmp/requirements.txt
+COPY hashmancer/worker/requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache-dir -r /tmp/requirements.txt
 
 CMD ["python", "-m", "hashmancer.worker.hashmancer_worker.worker_agent"]

--- a/docker/worker/requirements.txt
+++ b/docker/worker/requirements.txt
@@ -1,3 +1,0 @@
-redis==6.2.0
-requests==2.32.4
-cryptography==45.0.5


### PR DESCRIPTION
## Summary
- update worker Dockerfile to copy the package requirements from `hashmancer/worker`
- remove duplicate requirements file from `docker/worker`

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68890db3b12c8326bc58aab87a5d85d2