### PR TITLE
Support per-row hash_mode in import_hashes

### DIFF
--- a/hashmancer/server/README.md
+++ b/hashmancer/server/README.md
@@ -194,8 +194,11 @@ Validation failures return `400` with messages like `{\"detail\": \"mask too lon
 ### CSV format for `/import_hashes`
 
 Upload a CSV containing the following columns:
-`hash`, `mask`, `wordlist`, `target`, and `hash_mode`.
-`hash_mode` numbers follow [hashcat's list](https://hashcat.net/wiki/doku.php?id=example_hashes)
+`hash`, `mask`, `wordlist`, and `target`.
+You may also include a `hash_mode` column to override the mode for each row.
+If the column is omitted or a row is blank, the `hash_mode` query parameter
+is used for that row. `hash_mode` numbers follow
+[hashcat's list](https://hashcat.net/wiki/doku.php?id=example_hashes)
 (also available on the portal).
 
 Example:

--- a/hashmancer/server/main.py
+++ b/hashmancer/server/main.py
@@ -1152,6 +1152,7 @@ async def import_hashes(file: UploadFile = File(...), hash_mode: str = "0"):
             raise HTTPException(400, "invalid csv")
         header_line, buffer = buffer.split(b"\n", 1)
         fieldnames = next(csv.reader([header_line.decode()]))
+        has_hash_mode = "hash_mode" in fieldnames
         line_num = 0
 
         async def iter_lines():
@@ -1184,8 +1185,10 @@ async def import_hashes(file: UploadFile = File(...), hash_mode: str = "0"):
                 raise HTTPException(status_code=400, detail="mask too long")
             wordlist = (row.get("wordlist") or "").strip()
             target = row.get("target") or "any"
+            row_mode = (row.get("hash_mode") or "").strip() if has_hash_mode else ""
+            hm = row_mode or hash_mode
             batch_id = redis_manager.store_batch(
-                [h], mask=mask, wordlist=wordlist, rule="", target=target, hash_mode=hash_mode
+                [h], mask=mask, wordlist=wordlist, rule="", target=target, hash_mode=hm
             )
             if batch_id:
                 queued.append(batch_id)

--- a/tests/test_import_hashes.py
+++ b/tests/test_import_hashes.py
@@ -50,7 +50,11 @@ def test_import_hashes(monkeypatch):
         return f"id{len(calls)}"
     monkeypatch.setattr(redis_manager, 'store_batch', fake_store_batch)
     monkeypatch.setattr(main, 'log_error', lambda *a, **k: None)
-    data = b"hash,mask,wordlist,target\nh1,?a,wl.txt,t1\nh2,,,\n"
+    data = (
+        b"hash,mask,wordlist,target,hash_mode\n"
+        b"h1,?a,wl.txt,t1,1200\n"
+        b"h2,,,,1400\n"
+    )
     file = FakeUploadFile('hashes.csv', data)
     resp = asyncio.run(main.import_hashes(file, '1000'))
     assert resp == {"queued": 2, "errors": []}
@@ -60,7 +64,7 @@ def test_import_hashes(monkeypatch):
             "mask": "?a",
             "wordlist": "wl.txt",
             "target": "t1",
-            "hash_mode": "1000",
+            "hash_mode": "1200",
             "rule": "",
             "priority": 0,
         },
@@ -69,7 +73,7 @@ def test_import_hashes(monkeypatch):
             "mask": "",
             "wordlist": "",
             "target": "any",
-            "hash_mode": "1000",
+            "hash_mode": "1400",
             "rule": "",
             "priority": 0,
         },


### PR DESCRIPTION
## Summary
- allow `/import_hashes` to read a `hash_mode` column in the CSV
- update docs for optional `hash_mode` column
- adjust tests for row-level `hash_mode`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688919b40b60832694504b5f46fca78c