### PR TITLE
Add single hash import endpoint

### DIFF
--- a/hashmancer/server/main.py
+++ b/hashmancer/server/main.py
@@ -1202,6 +1202,21 @@ async def import_hashes(file: UploadFile = File(...), hash_mode: str = "0"):
         raise HTTPException(status_code=500, detail="import failed")
 
 
+@app.post("/import_hash")
+async def import_hash(hash: str, hash_mode: str = "0"):
+    """Queue a single hash for cracking."""
+    try:
+        batch_id = redis_manager.store_batch([hash], hash_mode=hash_mode)
+        if not batch_id:
+            raise HTTPException(status_code=500, detail="import failed")
+        return {"batch_id": batch_id}
+    except HTTPException:
+        raise
+    except Exception as e:  # pragma: no cover - unexpected failure
+        log_error("server", "system", "S726", "Failed to import hashes", e)
+        raise HTTPException(status_code=500, detail="import failed")
+
+
 
 
 async def train_llm(req: TrainLLMRequest):

--- a/hashmancer/server/portal.html
+++ b/hashmancer/server/portal.html
@@ -109,6 +109,11 @@ body::before {
 <input type="file" id="hash-file">
 <input type="number" id="hash-mode">
 <button onclick="uploadHashes()">Upload</button>
+<div>
+  <input type="text" id="single-hash" placeholder="hash">
+  <input type="number" id="single-hash-mode" placeholder="mode">
+  <button onclick="submitHash()">Queue</button>
+</div>
 </section>
 
 <section id="masks">
@@ -292,6 +297,17 @@ async function uploadHashes(){
   await fetch('/import_hashes',{method:'POST',body:fd});
   document.getElementById('hash-file').value='';
   document.getElementById('hash-mode').value='';
+  updateMetrics();
+  loadJobs();
+}
+
+async function submitHash(){
+  const hash=document.getElementById('single-hash').value.trim();
+  if(!hash) return;
+  const mode=document.getElementById('single-hash-mode').value.trim()||'0';
+  await fetch('/import_hash',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({hash,hash_mode:mode})});
+  document.getElementById('single-hash').value='';
+  document.getElementById('single-hash-mode').value='';
   updateMetrics();
   loadJobs();
 }

--- a/tests/test_server_import_hash.py
+++ b/tests/test_server_import_hash.py
@@ -1,0 +1,40 @@
+import asyncio
+import pytest
+
+from tests.test_helpers import (
+    fastapi_stub,
+    cors_stub,
+    resp_stub,
+
+    install_stubs,
+    FakeApp,
+)
+
+install_stubs()
+
+import hashmancer.server.main as main
+from utils import redis_manager
+
+
+def test_import_hash(monkeypatch):
+    called = {}
+
+    def fake_store(hashes, mask="", wordlist="", rule="", ttl=1800, target="any", hash_mode="0", priority=0):
+        called["hashes"] = hashes
+        called["mode"] = hash_mode
+        return "id1"
+
+    monkeypatch.setattr(redis_manager, "store_batch", fake_store)
+    monkeypatch.setattr(main, "log_error", lambda *a, **k: None)
+
+    resp = asyncio.run(main.import_hash("abc", "1400"))
+    assert resp == {"batch_id": "id1"}
+    assert called["hashes"] == ["abc"]
+    assert called["mode"] == "1400"
+
+
+def test_import_hash_failure(monkeypatch):
+    monkeypatch.setattr(redis_manager, "store_batch", lambda *a, **kw: None)
+    with pytest.raises(main.HTTPException):
+        asyncio.run(main.import_hash("a", "0"))
+


### PR DESCRIPTION
## Summary
- extend portal to submit a single hash
- post new single-hash data to the server
- support `/import_hash` endpoint in the server
- test the new endpoint

## Testing
- `pytest -q tests/test_server_import_hash.py`

------
https://chatgpt.com/codex/tasks/task_e_68891c6164208326adb308e70fb5b7dc