### PR TITLE
Add hash batch lookup endpoint

### DIFF
--- a/hashmancer/server/README.md
+++ b/hashmancer/server/README.md
@@ -178,6 +178,7 @@ performance over time.
 | GET    | `/rules`            | List available hashcat rules        |
 | GET    | `/workers`          | List registered workers             |
 | GET    | `/hashrate`         | Aggregate hashrate of all workers   |
+| GET    | `/hash_batches/{hash}` | List batch IDs for a hash           |
 | POST   | `/worker_status`    | Update a worker's status (optional signature) |
 | POST   | `/submit_benchmark` | Submit benchmark results            |
 

--- a/hashmancer/server/main.py
+++ b/hashmancer/server/main.py
@@ -1395,6 +1395,16 @@ async def list_jobs():
         return []
 
 
+@app.get("/hash_batches/{hash_value}")
+async def get_hash_batches(hash_value: str):
+    """Return batch IDs that include the given hash."""
+    try:
+        return redis_manager.get_hash_batches(hash_value)
+    except redis.exceptions.RedisError as e:
+        log_error("server", "system", "SRED", "Redis unavailable", e)
+        return []
+
+
 @app.get("/found_results")
 async def list_found_results(limit: int = 100):
     """Return recent found results."""

--- a/hashmancer/server/server_utils/redis_manager.py
+++ b/hashmancer/server/server_utils/redis_manager.py
@@ -104,3 +104,12 @@ def update_status(batch_id: str, status: str) -> None:
             r.persist(f"batch:{batch_id}")
     except redis.exceptions.RedisError as e:
         logging.warning("Redis unavailable: %s", e)
+
+
+def get_hash_batches(hash_value: str) -> list[str]:
+    """Return batch IDs associated with the given hash."""
+    try:
+        return list(r.smembers(f"hash_batches:{hash_value}"))
+    except redis.exceptions.RedisError as e:
+        logging.warning("Redis unavailable: %s", e)
+        return []

--- a/tests/test_redis_manager.py
+++ b/tests/test_redis_manager.py
@@ -71,3 +71,16 @@ def test_store_and_get_batch(monkeypatch):
     assert data["mask"] == "?a"
     assert data["keyspace"] == 10
     assert batch_id in fake.smembers("hash_batches:h")
+
+
+def test_get_hash_batches(monkeypatch):
+    fake = FakeRedis()
+    monkeypatch.setattr(redis_manager, "r", fake)
+    monkeypatch.setattr(redis_manager.uuid, "uuid4", lambda: UUID("22222222-2222-2222-2222-222222222222"))
+    monkeypatch.setattr(redis_manager.orchestrator_agent, "build_mask_charsets", lambda: {})
+    monkeypatch.setattr(redis_manager.orchestrator_agent, "estimate_keyspace", lambda m, c: 10)
+
+    batch_id = redis_manager.store_batch(["x", "y"])
+    batches = redis_manager.get_hash_batches("x")
+    assert batch_id in batches
+    assert redis_manager.get_hash_batches("missing") == []

--- a/tests/test_server_hash_batches.py
+++ b/tests/test_server_hash_batches.py
@@ -1,0 +1,36 @@
+import asyncio
+
+from tests.test_helpers import (
+    fastapi_stub,
+    cors_stub,
+    resp_stub,
+    install_stubs,
+    FakeApp,
+)
+
+install_stubs()
+
+import hashmancer.server.main as main
+from utils import redis_manager
+
+
+class FakeRedis:
+    def __init__(self):
+        self.sets = {}
+
+    def smembers(self, key):
+        return self.sets.get(key, set())
+
+
+async def call():
+    return await main.get_hash_batches("h1")
+
+
+def test_get_hash_batches(monkeypatch):
+    fake = FakeRedis()
+    fake.sets["hash_batches:h1"] = {"b1", "b2"}
+    monkeypatch.setattr(main, "r", fake)
+    monkeypatch.setattr(redis_manager, "r", fake)
+
+    res = asyncio.run(call())
+    assert set(res) == {"b1", "b2"}


### PR DESCRIPTION
## Summary
- implement `get_hash_batches` helper in `redis_manager`
- expose `/hash_batches/{hash}` API endpoint
- document the new endpoint
- add related unit tests

## Testing
- `pip install -q -r requirements-dev.txt`
- `pytest -q`
- `flake8`

------
https://chatgpt.com/codex/tasks/task_e_688921bd8ac083269b8dffb200db30eb