### PR TITLE
Use MAX_MASK_LEN constant

### DIFF
--- a/hashmancer/worker/hashmancer_worker/gpu_sidecar.py
+++ b/hashmancer/worker/hashmancer_worker/gpu_sidecar.py
@@ -4,7 +4,7 @@ import threading
 import redis
 from hashmancer.utils.event_logger import log_error, log_info
 from redis.exceptions import RedisError
-from ...utils.gpu_constants import (
+from hashmancer.utils.gpu_constants import (
     MAX_HASHES,
     MAX_MASK_LEN,
     MAX_RESULT_BUFFER,
@@ -469,8 +469,10 @@ class GPUSidecar(threading.Thread):
                 count += 1
             return count
 
-        if _count_mask(batch.get("mask", "")) >= 56:
-            raise ValueError("darkling-engine supports masks <56 characters")
+        if _count_mask(batch.get("mask", "")) >= MAX_MASK_LEN:
+            raise ValueError(
+                f"darkling-engine supports masks <{MAX_MASK_LEN} characters"
+            )
 
         mask_charsets = batch.get("mask_charsets")
         cs_map = {}

--- a/tests/test_gpu_sidecar.py
+++ b/tests/test_gpu_sidecar.py
@@ -443,14 +443,14 @@ def test_darkling_mask_length_limit(monkeypatch):
     batch = {
         "batch_id": "joblen",
         "hashes": json.dumps(["h"]),
-        "mask": "a" * 55,
+        "mask": "a" * (gpu_sidecar.MAX_MASK_LEN - 1),
         "attack_mode": "mask",
         "hash_mode": "0",
     }
 
     sidecar.run_darkling_engine(batch)
 
-    batch["mask"] = "a" * 56
+    batch["mask"] = "a" * gpu_sidecar.MAX_MASK_LEN
     with pytest.raises(ValueError):
         sidecar.run_darkling_engine(batch)
 


### PR DESCRIPTION
## Summary
- import `MAX_MASK_LEN` from `hashmancer.utils.gpu_constants`
- use the constant instead of a literal in `GPUSidecar`
- reference the constant in the error message
- update mask-length unit test

## Testing
- `pip install -q -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889322ca1d08326af72a72790802e33