### PR TITLE
Enable HIP and OpenCL darkling backends

### DIFF
--- a/hashmancer/darkling/backend_dispatcher.cpp
+++ b/hashmancer/darkling/backend_dispatcher.cpp
@@ -27,6 +27,11 @@ static GpuBackend detect_backend(const char* override_backend = nullptr) {
     return GpuBackend::NVIDIA_CUDA;
 }
 
+extern "C" GpuBackend test_detect_backend(const char* override_backend) {
+    return detect_backend(override_backend);
+}
+
+#ifndef DARKLING_NO_MAIN
 int main(int argc, char** argv) {
     const char* override = nullptr;
     for (int i = 1; i < argc; ++i) {
@@ -59,3 +64,4 @@ int main(int argc, char** argv) {
     std::cout << status.hashes_processed << std::endl;
     return 0;
 }
+#endif


### PR DESCRIPTION
## Summary
- implement HIP and OpenCL kernels
- expose `test_detect_backend` helper and optional main in dispatcher
- expand documentation for HIP/OpenCL
- add tests for dispatcher detection logic

## Testing
- `flake8`
- `pytest tests/test_darkling_backends.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688967ab026483268133f574f5ef7e98