### PR TITLE
Add HTTP retry helpers and apply to workers

### DIFF
--- a/hashmancer/utils/http_utils.py
+++ b/hashmancer/utils/http_utils.py
@@ -1,0 +1,29 @@
+import time
+import requests
+from requests import RequestException
+
+
+def post_with_retry(url: str, *, retries: int = 3, backoff: float = 1.0, **kwargs):
+    """Send a POST request retrying on transient errors."""
+    delay = backoff
+    for attempt in range(retries):
+        try:
+            return requests.post(url, **kwargs)
+        except RequestException:
+            if attempt == retries - 1:
+                raise
+            time.sleep(delay)
+            delay = min(delay * 2, 30)
+
+
+def get_with_retry(url: str, *, retries: int = 3, backoff: float = 1.0, **kwargs):
+    """Send a GET request retrying on transient errors."""
+    delay = backoff
+    for attempt in range(retries):
+        try:
+            return requests.get(url, **kwargs)
+        except RequestException:
+            if attempt == retries - 1:
+                raise
+            time.sleep(delay)
+            delay = min(delay * 2, 30)

--- a/tests/test_gpu_sidecar.py
+++ b/tests/test_gpu_sidecar.py
@@ -58,7 +58,7 @@ def test_run_hashcat(monkeypatch):
         return DummyProc(['{"speed": [50], "progress": 10}'], "/tmp/job1.out")
 
     monkeypatch.setattr(gpu_sidecar.subprocess, "Popen", fake_popen)
-    monkeypatch.setattr(gpu_sidecar.requests, "post", lambda *a, **k: None)
+    monkeypatch.setattr(gpu_sidecar, "post_with_retry", lambda *a, **k: None)
     monkeypatch.setattr(gpu_sidecar, "sign_message", lambda *a: "sig")
 
     batch = {
@@ -88,7 +88,7 @@ def test_darkling_engine_selected(monkeypatch):
 
         return Resp()
 
-    monkeypatch.setattr(gpu_sidecar.requests, "get", fake_get)
+    monkeypatch.setattr(gpu_sidecar, "get_with_retry", fake_get)
     sidecar = gpu_sidecar.GPUSidecar(
         "worker",
         {"uuid": "gpu", "index": 0, "pci_link_width": 4},
@@ -104,7 +104,7 @@ def test_darkling_engine_selected(monkeypatch):
         return DummyProc(["{}"], "/tmp/job2.out")
 
     monkeypatch.setattr(gpu_sidecar.subprocess, "Popen", fake_popen)
-    monkeypatch.setattr(gpu_sidecar.requests, "post", lambda *a, **k: None)
+    monkeypatch.setattr(gpu_sidecar, "post_with_retry", lambda *a, **k: None)
     monkeypatch.setattr(gpu_sidecar, "sign_message", lambda *a: "sig")
 
     batch = {
@@ -135,7 +135,7 @@ def test_custom_mask_charsets(monkeypatch):
         return DummyProc(["{}"], "/tmp/job7.out")
 
     monkeypatch.setattr(gpu_sidecar.subprocess, "Popen", fake_popen)
-    monkeypatch.setattr(gpu_sidecar.requests, "post", lambda *a, **k: None)
+    monkeypatch.setattr(gpu_sidecar, "post_with_retry", lambda *a, **k: None)
     monkeypatch.setattr(gpu_sidecar, "sign_message", lambda *a: "sig")
 
     batch = {
@@ -165,7 +165,7 @@ def test_reuse_preloaded_charsets(monkeypatch):
         return DummyProc(["{}"], f"/tmp/job8{len(cmds)}.out")
 
     monkeypatch.setattr(gpu_sidecar.subprocess, "Popen", fake_popen)
-    monkeypatch.setattr(gpu_sidecar.requests, "post", lambda *a, **k: None)
+    monkeypatch.setattr(gpu_sidecar, "post_with_retry", lambda *a, **k: None)
     monkeypatch.setattr(gpu_sidecar, "sign_message", lambda *a: "sig")
 
     batch = {
@@ -201,7 +201,7 @@ def test_power_limit_nvidia(monkeypatch):
 
     monkeypatch.setattr(gpu_sidecar.subprocess, "check_call", fake_check_call)
     monkeypatch.setattr(gpu_sidecar.subprocess, "Popen", fake_popen)
-    monkeypatch.setattr(gpu_sidecar.requests, "post", lambda *a, **k: None)
+    monkeypatch.setattr(gpu_sidecar, "post_with_retry", lambda *a, **k: None)
     monkeypatch.setattr(gpu_sidecar, "sign_message", lambda *a: "sig")
 
     batch = {
@@ -238,7 +238,7 @@ def test_power_limit_rocm(monkeypatch):
 
     monkeypatch.setattr(gpu_sidecar.subprocess, "check_call", fake_check_call)
     monkeypatch.setattr(gpu_sidecar.subprocess, "Popen", fake_popen)
-    monkeypatch.setattr(gpu_sidecar.requests, "post", lambda *a, **k: None)
+    monkeypatch.setattr(gpu_sidecar, "post_with_retry", lambda *a, **k: None)
     monkeypatch.setattr(gpu_sidecar, "sign_message", lambda *a: "sig")
 
     batch = {
@@ -275,7 +275,7 @@ def test_power_overdrive_rocm(monkeypatch):
 
     monkeypatch.setattr(gpu_sidecar.subprocess, "check_call", fake_check_call)
     monkeypatch.setattr(gpu_sidecar.subprocess, "Popen", fake_popen)
-    monkeypatch.setattr(gpu_sidecar.requests, "post", lambda *a, **k: None)
+    monkeypatch.setattr(gpu_sidecar, "post_with_retry", lambda *a, **k: None)
     monkeypatch.setattr(gpu_sidecar, "sign_message", lambda *a: "sig")
 
     batch = {
@@ -311,7 +311,7 @@ def test_power_limit_intel(monkeypatch):
 
     monkeypatch.setattr(gpu_sidecar.subprocess, "check_call", fake_check_call)
     monkeypatch.setattr(gpu_sidecar.subprocess, "Popen", fake_popen)
-    monkeypatch.setattr(gpu_sidecar.requests, "post", lambda *a, **k: None)
+    monkeypatch.setattr(gpu_sidecar, "post_with_retry", lambda *a, **k: None)
     monkeypatch.setattr(gpu_sidecar, "sign_message", lambda *a: "sig")
 
     batch = {
@@ -343,7 +343,7 @@ def test_sidecar_run_executes_job(monkeypatch):
             return DummyResp({"low_bw_engine": "hashcat"})
         return DummyResp({"batch_id": "job6", "hashes": "[]", "mask": "", "attack_mode": "mask"})
 
-    monkeypatch.setattr(gpu_sidecar.requests, "get", fake_get)
+    monkeypatch.setattr(gpu_sidecar, "get_with_retry", fake_get)
     monkeypatch.setattr(gpu_sidecar, "sign_message", lambda *a: "sig")
     monkeypatch.setattr(gpu_sidecar, "r", FakeRedis())
 
@@ -437,7 +437,7 @@ def test_darkling_mask_length_limit(monkeypatch):
         return DummyProc(["{}"], "/tmp/joblen.out")
 
     monkeypatch.setattr(gpu_sidecar.subprocess, "Popen", fake_popen)
-    monkeypatch.setattr(gpu_sidecar.requests, "post", lambda *a, **k: None)
+    monkeypatch.setattr(gpu_sidecar, "post_with_retry", lambda *a, **k: None)
     monkeypatch.setattr(gpu_sidecar, "sign_message", lambda *a: "sig")
 
     batch = {
@@ -466,7 +466,7 @@ def test_darkling_hash_batching(monkeypatch):
         return [f"{h}:pass" for h in json.loads(batch["hashes"])]
 
     monkeypatch.setattr(gpu_sidecar.GPUSidecar, "_run_engine", fake_run_engine)
-    monkeypatch.setattr(gpu_sidecar.requests, "post", lambda *a, **k: None)
+    monkeypatch.setattr(gpu_sidecar, "post_with_retry", lambda *a, **k: None)
     monkeypatch.setattr(gpu_sidecar, "sign_message", lambda *a: "sig")
 
     hashes = [f"h{i}" for i in range(gpu_sidecar.MAX_HASHES + 5)]

--- a/tests/test_http_utils.py
+++ b/tests/test_http_utils.py
@@ -1,0 +1,36 @@
+import requests
+import pytest
+from hashmancer.utils import http_utils
+
+class DummyResp:
+    def __init__(self, data):
+        self._data = data
+    def json(self):
+        return self._data
+
+
+def test_post_with_retry(monkeypatch):
+    calls = []
+    def flaky_post(url, **kwargs):
+        calls.append(1)
+        if len(calls) < 3:
+            raise requests.RequestException("fail")
+        return DummyResp({"ok": True})
+
+    sleeps = []
+    monkeypatch.setattr(http_utils.requests, "post", flaky_post)
+    monkeypatch.setattr(http_utils.time, "sleep", lambda s: sleeps.append(s))
+
+    resp = http_utils.post_with_retry("http://sv", retries=5, backoff=0.1)
+    assert resp.json()["ok"] is True
+    assert len(calls) == 3
+    assert len(sleeps) == 2
+
+
+def test_get_with_retry_failure(monkeypatch):
+    monkeypatch.setattr(http_utils.requests, "get", lambda *a, **k: (_ for _ in ()).throw(requests.RequestException("fail")))
+    sleeps = []
+    monkeypatch.setattr(http_utils.time, "sleep", lambda s: sleeps.append(s))
+    with pytest.raises(requests.RequestException):
+        http_utils.get_with_retry("http://sv", retries=2, backoff=0.1)
+    assert len(sleeps) == 1

--- a/tests/test_worker_agent.py
+++ b/tests/test_worker_agent.py
@@ -34,7 +34,7 @@ def test_register_worker_success(monkeypatch):
     def mock_post(url, json=None, timeout=None):
         return DummyResp({"status": "ok", "waifu": "TestWaifu"})
 
-    monkeypatch.setattr(worker_agent.requests, "post", mock_post)
+    monkeypatch.setattr(worker_agent, "post_with_retry", mock_post)
     monkeypatch.setattr(worker_agent, "load_public_key_pem", lambda: "PUB")
     monkeypatch.setattr(worker_agent, "sign_message", lambda *a: "sig")
 
@@ -80,8 +80,8 @@ def test_register_worker_retry(monkeypatch):
     monkeypatch.setattr(worker_agent, "r", fake)
 
     monkeypatch.setattr(
-        worker_agent.requests,
-        "post",
+        worker_agent,
+        "post_with_retry",
         lambda url, json=None, timeout=None: DummyResp({"status": "ok", "waifu": "W"}),
     )
     monkeypatch.setattr(worker_agent, "load_public_key_pem", lambda: "PUB")
@@ -118,8 +118,8 @@ def test_benchmark_low_bw_gpu(monkeypatch):
     monkeypatch.setattr(worker_agent, "register_worker", lambda wid, g, p=None: "name")
 
     monkeypatch.setattr(
-        worker_agent.requests,
-        "get",
+        worker_agent,
+        "get_with_retry",
         lambda url, timeout=5, **kwargs: DummyResp(
             {
                 "low_bw_engine": "darkling",
@@ -142,7 +142,7 @@ def test_benchmark_low_bw_gpu(monkeypatch):
     monkeypatch.setattr(
         worker_agent, "run_hashcat_benchmark", lambda g, engine="hashcat": {}
     )
-    monkeypatch.setattr(worker_agent.requests, "post", fake_post)
+    monkeypatch.setattr(worker_agent, "post_with_retry", fake_post)
     monkeypatch.setattr(worker_agent, "sign_message", lambda *a: "sig")
 
     class DummySidecar:
@@ -207,8 +207,8 @@ def test_prob_order_from_server(monkeypatch):
     monkeypatch.setattr(worker_agent, "register_worker", lambda wid, g, p=None: "name")
 
     monkeypatch.setattr(
-        worker_agent.requests,
-        "get",
+        worker_agent,
+        "get_with_retry",
         lambda url, timeout=5, **kwargs: DummyResp(
             {
                 "low_bw_engine": "hashcat",
@@ -227,7 +227,7 @@ def test_prob_order_from_server(monkeypatch):
     monkeypatch.setattr(
         worker_agent, "run_hashcat_benchmark", lambda g, engine="hashcat": {}
     )
-    monkeypatch.setattr(worker_agent.requests, "post", fake_post)
+    monkeypatch.setattr(worker_agent, "post_with_retry", fake_post)
     monkeypatch.setattr(worker_agent, "sign_message", lambda *a: "sig")
 
     class DummySidecar:
@@ -290,8 +290,8 @@ def test_prob_order_from_server(monkeypatch):
 def test_check_worker_command(monkeypatch):
     calls = []
     monkeypatch.setattr(
-        worker_agent.requests,
-        "get",
+        worker_agent,
+        "get_with_retry",
         lambda url, params=None, timeout=5: DummyResp({"status": "ok", "command": "upgrade"}),
     )
     monkeypatch.setattr(worker_agent, "sign_message", lambda *a: "sig")


### PR DESCRIPTION
## Summary
- add `http_utils` with `post_with_retry` and `get_with_retry`
- use retry helpers in worker agent and GPU sidecar
- update tests to patch new helpers
- add new tests for HTTP retry behaviour

## Testing
- `pytest tests/test_http_utils.py tests/test_worker_agent.py::test_register_worker_success tests/test_gpu_sidecar.py::test_run_hashcat -q`

------
https://chatgpt.com/codex/tasks/task_e_68896a81c5f88326aac73ddc5b204a66