### PR TITLE
Clarify DarklingContext docstrings

### DIFF
--- a/hashmancer/worker/hashmancer_worker/gpu_sidecar.py
+++ b/hashmancer/worker/hashmancer_worker/gpu_sidecar.py
@@ -61,14 +61,23 @@ MAX_CHARSETS = 16
 
 
 class DarklingContext:
-    """Per-GPU context keeping the darkling engine state."""
+    """Per-GPU context for the darkling engine state.
+
+    This object only tracks information about charsets in Python so the worker
+    can avoid reloading them unnecessarily.  It does not allocate or manage GPU
+    memory.
+    """
 
     def __init__(self):
         self.charsets_json: str | None = None
 
     def load(self, charsets: dict):
-        """Record the loaded charsets. In a real setup this would preload them
-        on the GPU."""
+        """Store the charset mapping for later comparison.
+
+        The mapping is serialized to JSON so subsequent calls can detect
+        whether the same charsets were previously loaded.  Actual GPU
+        preloading is not implemented here.
+        """
         self.charsets_json = json.dumps(charsets, sort_keys=True)
 
     def matches(self, charsets: dict) -> bool:


### PR DESCRIPTION
## Summary
- clarify how DarklingContext stores charset mappings
- note that no GPU memory is involved

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688977ac00888326990e52def14048e5