### PR TITLE
Improve GPU sidecar cache handling

### DIFF
--- a/hashmancer/worker/hashmancer_worker/gpu_sidecar.py
+++ b/hashmancer/worker/hashmancer_worker/gpu_sidecar.py
@@ -306,6 +306,32 @@ class GPUSidecar(threading.Thread):
         restore = Path(f"/tmp/{batch_id}.restore")
 
         wordlist_path = batch.get("wordlist")
+        job_id = batch.get("job_id", batch_id)
+
+        if not wordlist_path or not os.path.isfile(str(wordlist_path)):
+            cached = _safe_redis_call(
+                r.hget, f"vram:{self.gpu['uuid']}:{job_id}", "payload"
+            )
+            if cached:
+                try:
+                    cached_batch = json.loads(cached)
+                    for k, v in cached_batch.items():
+                        batch.setdefault(k, v)
+                except json.JSONDecodeError:
+                    pass
+                wordlist_path = batch.get("wordlist")
+
+            if not wordlist_path or not os.path.isfile(str(wordlist_path)):
+                data = _safe_redis_call(
+                    r.get, f"vram:{self.gpu['uuid']}:{job_id}:wordlist"
+                )
+                if data:
+                    tmp = Path(f"/tmp/{batch_id}.wl")
+                    if isinstance(data, str):
+                        data = data.encode()
+                    tmp.write_bytes(data)
+                    wordlist_path = str(tmp)
+                    batch["wordlist"] = wordlist_path
 
         founds: list[str] = []
         try:
@@ -446,6 +472,11 @@ class GPUSidecar(threading.Thread):
                     and wordlist_path.endswith(".wl")
                 ):
                     Path(wordlist_path).unlink(missing_ok=True)
+                _safe_redis_call(
+                    r.delete,
+                    f"vram:{self.gpu['uuid']}:{job_id}",
+                    f"vram:{self.gpu['uuid']}:{job_id}:wordlist",
+                )
             except OSError:
                 pass
 


### PR DESCRIPTION
## Summary
- handle cached payload and wordlist retrieval in `GPUSidecar._run_engine`
- purge cached data after job completion
- extend `FakeRedis` helper in gpu sidecar tests
- test cached wordlist retrieval

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688977d9607483269f4a9ea0da756d6e