### PR TITLE
Implement darkling power tuning

### DIFF
--- a/hashmancer/worker/README.md
+++ b/hashmancer/worker/README.md
@@ -89,6 +89,18 @@ Two optional environment variables allow you to tweak how `hashcat` runs:
 - `DARKLING_GPU_POWER_LIMIT` – similar to `GPU_POWER_LIMIT` but only applied
   when the darkling engine is used. This allows independent tuning of
   experimental kernels.
+- `DARKLING_AUTOTUNE` – when set, the worker runs a short tuning pass for
+  `darkling-engine` to adjust grid and block sizes.
+- `DARKLING_TARGET_POWER_LIMIT` – desired power draw in watts used during
+  autotuning and as a fallback power cap for darkling jobs.
+
+### Darkling autotuning
+
+When `DARKLING_AUTOTUNE` is enabled the worker launches `darkling-engine`
+on a small range without grid or block overrides and checks GPU power draw.
+If consumption exceeds `DARKLING_TARGET_POWER_LIMIT` the grid and block values
+are halved until the reading falls below the target.  Tuned values are stored
+per GPU and exported via `DARKLING_GRID`/`DARKLING_BLOCK` for subsequent runs.
 
 Grid and block sizes for the darkling engine can also be set per GPU model in
 `~/.hashmancer/worker_config.json`.  Add a `darkling_tuning` object mapping


### PR DESCRIPTION
## Summary
- add darkling autotune env variables
- tune darkling grid/block based on power usage
- respect DARKLING_TARGET_POWER_LIMIT in power limiter
- document darkling autotuning
- test power limit and autotune logic

## Testing
- `pytest tests/test_gpu_sidecar.py::test_apply_power_limit_darkling -q`
- `pytest tests/test_gpu_sidecar.py::test_darkling_autotune -q`
- `pytest tests/test_gpu_sidecar.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6889896d7ed083268cc42bdf8f80e04c