### PR TITLE
feat: add GitHub issue helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,3 +146,15 @@ fully conform to the default style yet, so ``.flake8`` extends the ignore list
 (E203, E225, E301, E302, E303, E305, E306, E401, E402, E501, E741,
 F401, F541, F811, F824, W291, W292, W391). This allows the current codebase to
 pass the lint step while work continues on modernization.
+
+## GitHub Issue helper
+
+Hashmancer can open issues on GitHub using a personal access token stored in
+`GITHUB_TOKEN`. The helper function `hashmancer.utils.github_client.create_issue`
+wraps the API call:
+
+```python
+from hashmancer.utils.github_client import create_issue
+
+create_issue("Infernal-Insights/Hashmancer", "Bug title", "Details about the bug")
+```

--- a/hashmancer/utils/__init__.py
+++ b/hashmancer/utils/__init__.py
@@ -1,5 +1,6 @@
 """Shared utilities for Hashmancer components."""
 
 from ..server.server_utils import redis_manager
+from .github_client import create_issue
 
-__all__ = ["redis_manager"]
+__all__ = ["redis_manager", "create_issue"]

--- a/hashmancer/utils/github_client.py
+++ b/hashmancer/utils/github_client.py
@@ -1,0 +1,44 @@
+import os
+from typing import Any
+
+import requests
+
+
+def _load_token(token: str | None = None) -> str:
+    tok = token or os.environ.get("GITHUB_TOKEN")
+    if not tok:
+        raise RuntimeError("GITHUB_TOKEN not configured")
+    return tok
+
+
+def create_issue(repo: str, title: str, body: str = "", token: str | None = None) -> dict[str, Any]:
+    """Create a GitHub issue for ``repo`` using ``GITHUB_TOKEN``.
+
+    Parameters
+    ----------
+    repo:
+        Repository in ``owner/name`` form.
+    title:
+        Title for the new issue.
+    body:
+        Optional issue body.
+    token:
+        Personal access token override. If omitted, ``GITHUB_TOKEN`` is used.
+
+    Returns
+    -------
+    dict
+        Parsed JSON response from the GitHub API.
+    """
+    tok = _load_token(token)
+    url = f"https://api.github.com/repos/{repo}/issues"
+    headers = {
+        "Authorization": f"token {tok}",
+        "Accept": "application/vnd.github+json",
+    }
+    payload: dict[str, Any] = {"title": title}
+    if body:
+        payload["body"] = body
+    resp = requests.post(url, headers=headers, json=payload, timeout=10)
+    resp.raise_for_status()
+    return resp.json()

--- a/tests/test_github_client.py
+++ b/tests/test_github_client.py
@@ -1,0 +1,39 @@
+import requests
+import pytest
+
+from hashmancer.utils.github_client import create_issue
+
+
+class DummyResponse:
+    def __init__(self):
+        self.status_code = 201
+
+    def raise_for_status(self) -> None:  # pragma: no cover - always ok
+        return None
+
+    def json(self):
+        return {"url": "https://api.github.com/repos/owner/repo/issues/1"}
+
+
+def test_create_issue_requires_token(monkeypatch):
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    with pytest.raises(RuntimeError):
+        create_issue("owner/repo", "t")
+
+
+def test_create_issue_posts(monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKEN", "secret")
+    data = {}
+
+    def fake_post(url, headers=None, json=None, timeout=0):
+        data["url"] = url
+        data["headers"] = headers
+        data["json"] = json
+        return DummyResponse()
+
+    monkeypatch.setattr(requests, "post", fake_post)
+
+    res = create_issue("owner/repo", "Title", "Body")
+    assert data["url"] == "https://api.github.com/repos/owner/repo/issues"
+    assert data["json"] == {"title": "Title", "body": "Body"}
+    assert res["url"].endswith("/issues/1")


### PR DESCRIPTION
## Summary
- add `github_client.create_issue` that reads token from `GITHUB_TOKEN`
- document GitHub issue helper in README
- cover token handling with tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689378e1df288326b6a4b6f4b45992f5