### PR TITLE
Use mmap for dict shard loading and add memory buffer path

### DIFF
--- a/darkling/include/darkling_dict.h
+++ b/darkling/include/darkling_dict.h
@@ -1,7 +1,17 @@
 #pragma once
 #include <stdint.h>
-struct DlShardView { const uint8_t* base; const uint32_t* offsets; uint64_t count; uint32_t words_offset; };
+#include <stddef.h>
+struct DlShardView {
+  const uint8_t* base;
+  const uint32_t* offsets;
+  uint64_t count;
+  uint32_t words_offset;
+  size_t bytes;
+  bool external;
+  bool registered;
+};
 bool  dl_map_shard(const char* path, DlShardView* out);
+bool  dl_map_shard_mem(const uint8_t* data, size_t bytes, DlShardView* out);
 void  dl_unmap_shard(DlShardView*);
 
 struct DlPinnedRing;

--- a/darkling/src/dict_loader.cpp
+++ b/darkling/src/dict_loader.cpp
@@ -2,30 +2,57 @@
 #include <stdlib.h>
 #include <string.h>
 #include <cuda_runtime.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
 #include "darkling_dict.h"
 
-bool dl_map_shard(const char* path, DlShardView* out) {
-  FILE* f = fopen(path, "rb");
-  if (!f) return false;
-  fseek(f, 0, SEEK_END);
-  size_t size = ftell(f);
-  fseek(f, 0, SEEK_SET);
-  uint8_t* data = (uint8_t*)malloc(size);
-  if (fread(data,1,size,f)!=size) { fclose(f); free(data); return false; }
-  fclose(f);
+static bool dl_map_shard_buffer(uint8_t* data, size_t size, bool external, DlShardView* out) {
+  if (size < sizeof(uint32_t)) return false;
   uint32_t count = ((uint32_t*)data)[0];
   size_t header = sizeof(uint32_t) + (count + 1) * sizeof(uint32_t);
-  if (size < header) { free(data); return false; }
+  if (size < header) return false;
+  uint32_t* offsets = (uint32_t*)(data + sizeof(uint32_t));
+  uint32_t sentinel = offsets[count];
+  if (header + sentinel > size) return false;
+  cudaError_t err = cudaHostRegister(data, size, cudaHostRegisterReadOnly);
   out->base = data;
-  out->offsets = (uint32_t*)(data + sizeof(uint32_t));
+  out->offsets = offsets;
   out->count = count;
   out->words_offset = header;
-  uint32_t sentinel = out->offsets[count];
-  if (out->words_offset + sentinel > size) { free(data); return false; }
+  out->bytes = size;
+  out->external = external;
+  out->registered = (err == cudaSuccess);
   return true;
 }
 
+bool dl_map_shard(const char* path, DlShardView* out) {
+  int fd = open(path, O_RDONLY);
+  if (fd < 0) return false;
+  struct stat st;
+  if (fstat(fd, &st) != 0) { close(fd); return false; }
+  size_t size = st.st_size;
+  uint8_t* data = (uint8_t*)mmap(NULL, size, PROT_READ, MAP_PRIVATE, fd, 0);
+  close(fd);
+  if (data == MAP_FAILED) return false;
+  if (!dl_map_shard_buffer(data, size, false, out)) {
+    munmap(data, size);
+    return false;
+  }
+  return true;
+}
+
+bool dl_map_shard_mem(const uint8_t* data, size_t size, DlShardView* out) {
+  return dl_map_shard_buffer((uint8_t*)data, size, true, out);
+}
+
 void dl_unmap_shard(DlShardView* v) {
-  free((void*)v->base);
+  if (!v->base) return;
+  if (v->registered) cudaHostUnregister((void*)v->base);
+  if (!v->external) {
+    munmap((void*)v->base, v->bytes);
+  }
   v->base = NULL;
 }
+

--- a/darkling/tests/test_loader.cpp
+++ b/darkling/tests/test_loader.cpp
@@ -1,6 +1,7 @@
 #include <assert.h>
 #include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
 #include "darkling_dict.h"
 
 int main() {
@@ -15,5 +16,14 @@ int main() {
   DlShardView v; bool ok = dl_map_shard(path,&v); assert(ok); assert(v.count==2);
   dl_unmap_shard(&v);
   remove(path);
+
+  size_t mem_size = 4 + 12 + 12;
+  uint8_t* mem = (uint8_t*)malloc(mem_size);
+  memcpy(mem, &count, 4);
+  memcpy(mem + 4, offsets, 12);
+  memcpy(mem + 16, "hello\nworld\n", 12);
+  DlShardView v2; bool ok2 = dl_map_shard_mem(mem, mem_size, &v2); assert(ok2); assert(v2.count==2);
+  dl_unmap_shard(&v2);
+  free(mem);
   return 0;
 }


### PR DESCRIPTION
## Summary
- load dictionary shards via `mmap` and register pages with CUDA for zero-copy access
- allow shards to be mapped directly from preloaded RAM buffers
- expand `DlShardView` and tests to support new loader capabilities

## Testing
- `nvcc ../tests/test_loader.cpp ../src/dict_loader.cpp -I ../include -o test_loader`
- `./test_loader && echo PASS`


------
https://chatgpt.com/codex/tasks/task_e_689bf4d065f88326bd820d296961e181