### PR TITLE
Return candidate length from rule functions

### DIFF
--- a/darkling/include/darkling_rules.h
+++ b/darkling/include/darkling_rules.h
@@ -13,8 +13,9 @@ struct DlRuleMC {
 
 struct RuleParams { uint8_t bytes[16]; };
 
-typedef void (*RuleFn)(uint8_t* dst, const uint8_t* src, uint32_t len,
-                       const RuleParams* params, uint32_t variant_idx, uint32_t variant_count);
+typedef uint32_t (*RuleFn)(uint8_t* dst, const uint8_t* src, uint32_t len,
+                           const RuleParams* params, uint32_t variant_idx,
+                           uint32_t variant_count);
 
 struct DlRuleDispatch {
   DlRuleShape shape;

--- a/darkling/src/dict_kernel_dispatch.cu
+++ b/darkling/src/dict_kernel_dispatch.cu
@@ -5,10 +5,10 @@
 #include "darkling_telemetry.h"
 #include "hash_primitives.cuh"
 
-extern "C" __device__ void rule_prefix_1(uint8_t* dst, const uint8_t* src, uint32_t len,
-                                         const RuleParams* params, uint32_t variant_idx, uint32_t variant_count);
-extern "C" __device__ void rule_suffix_d4(uint8_t* dst, const uint8_t* src, uint32_t len,
-                                           const RuleParams* params, uint32_t variant_idx, uint32_t variant_count);
+extern "C" __device__ uint32_t rule_prefix_1(uint8_t* dst, const uint8_t* src, uint32_t len,
+                                             const RuleParams* params, uint32_t variant_idx, uint32_t variant_count);
+extern "C" __device__ uint32_t rule_suffix_d4(uint8_t* dst, const uint8_t* src, uint32_t len,
+                                               const RuleParams* params, uint32_t variant_idx, uint32_t variant_count);
 
 __global__ void persistent_kernel(const uint8_t* words, const uint32_t* offsets, DlTelemetry* tel) {
   DlWorkItem item;
@@ -31,9 +31,9 @@ __global__ void persistent_kernel(const uint8_t* words, const uint32_t* offsets,
       DlRuleDispatch disp = g_dispatch[rule.shape];
       uint8_t tmp[64];
       for (uint32_t v = 0; v < 1; ++v) {
-        disp.fn(tmp, src, len, &params, v, disp.variants);
+        uint32_t candidate_len = disp.fn(tmp, src, len, &params, v, disp.variants);
         uint32_t dig[4];
-        md5_hash(tmp, len+1, dig);
+        md5_hash(tmp, candidate_len, dig);
         atomicAdd(&tel->candidates_generated, 1ULL);
       }
       atomicAdd(&tel->words_processed, 1ULL);

--- a/darkling/src/rule_dispatch.cu
+++ b/darkling/src/rule_dispatch.cu
@@ -1,20 +1,22 @@
 #include <cuda_runtime.h>
 #include "darkling_rules.h"
 
-extern "C" __device__ void rule_prefix_1(uint8_t* dst, const uint8_t* src, uint32_t len,
-                                         const RuleParams* params, uint32_t variant_idx, uint32_t variant_count) {
+extern "C" __device__ uint32_t rule_prefix_1(uint8_t* dst, const uint8_t* src, uint32_t len,
+                                             const RuleParams* params, uint32_t variant_idx, uint32_t variant_count) {
   static __constant__ uint8_t table[14] = { '!', '@', '#', '$', '%', '^', '&', '*', '(', ')', '_', '+', '=', '-' };
   uint8_t sym = table[params->bytes[0] % 14];
   dst[0] = sym;
   for (uint32_t i = 0; i < len; ++i) dst[i+1] = src[i];
+  return len + 1;
 }
 
-extern "C" __device__ void rule_suffix_d4(uint8_t* dst, const uint8_t* src, uint32_t len,
-                                          const RuleParams* params, uint32_t variant_idx, uint32_t variant_count) {
+extern "C" __device__ uint32_t rule_suffix_d4(uint8_t* dst, const uint8_t* src, uint32_t len,
+                                              const RuleParams* params, uint32_t variant_idx, uint32_t variant_count) {
   for (uint32_t i = 0; i < len; ++i) dst[i] = src[i];
   uint32_t v = variant_idx;
   dst[len+0] = '0' + (v % 10);
   dst[len+1] = '0' + ((v/10) % 10);
   dst[len+2] = '0' + ((v/100) % 10);
   dst[len+3] = '0' + ((v/1000) % 10);
+  return len + 4;
 }

--- a/darkling/src/rule_table.cu
+++ b/darkling/src/rule_table.cu
@@ -2,8 +2,10 @@
 #include <string.h>
 #include "darkling_rules.h"
 
-extern "C" __device__ void rule_prefix_1(uint8_t*, const uint8_t*, uint32_t, const RuleParams*, uint32_t, uint32_t);
-extern "C" __device__ void rule_suffix_d4(uint8_t*, const uint8_t*, uint32_t, const RuleParams*, uint32_t, uint32_t);
+extern "C" __device__ uint32_t rule_prefix_1(uint8_t*, const uint8_t*, uint32_t,
+                                             const RuleParams*, uint32_t, uint32_t);
+extern "C" __device__ uint32_t rule_suffix_d4(uint8_t*, const uint8_t*, uint32_t,
+                                               const RuleParams*, uint32_t, uint32_t);
 
 __device__ __constant__ DlRuleMC g_rules[256];
 __device__ __constant__ DlRuleDispatch g_dispatch[6];


### PR DESCRIPTION
## Summary
- Return generated candidate length from rule functions
- Hash candidate buffers using reported length instead of assuming `len + 1`

## Testing
- `pytest -q` *(fails: TypeError: <lambda>() got an unexpected keyword argument 'lifespan'; ModuleNotFoundError: No module named 'filelock')*


------
https://chatgpt.com/codex/tasks/task_e_689bf76c94ac832693affc3a4f08d930