### PR TITLE
Use darkling dict engine for dict_rules

### DIFF
--- a/hashmancer/darkling/README.md
+++ b/hashmancer/darkling/README.md
@@ -117,6 +117,14 @@ Precompiled binaries are published with each release. Set the environment
 variable `DARKLING_ENGINE_URL` before running `setup.py` on a worker to
 automatically download a ready-to-use `darkling-engine`.
 
+## Dictionary Mode
+
+`darkling-engine` also provides a dictionary attack mode which consumes
+pre‑generated shard files instead of plain wordlists. Each shard is supplied via
+`--shard /path/to/shard.bin` and a ruleset JSON is referenced with
+`--rules /path/to/rules.json`. The worker automatically adds these arguments
+when processing jobs with `attack_mode == "dict_rules"`.
+
 ### Runtime Configuration
 
 The dispatcher inspects the `DARKLING_GPU_BACKEND` variable to force a

--- a/tests/test_gpu_sidecar.py
+++ b/tests/test_gpu_sidecar.py
@@ -712,12 +712,15 @@ def test_run_darkling_dict_rules(monkeypatch, tmp_path):
         "hash_mode": "0",
         "wordlist": str(wl),
         "rules": str(rules),
+        "shards": json.dumps([str(wl)]),
     }
 
     sidecar._run_engine("darkling-engine", batch)
 
     assert "--rules" in captured["cmd"]
     assert str(rules) in captured["cmd"]
+    assert "--shard" in captured["cmd"]
+    assert str(wl) in captured["cmd"]
     assert captured["env"].get("DARKLING_RULES") == str(rules)
 
 


### PR DESCRIPTION
## Summary
- invoke darkling-engine when attack mode is `dict_rules`
- pass dictionary shards and rule config to the darkling engine
- document darkling dictionary mode and expected inputs

## Testing
- `pytest tests/test_gpu_sidecar.py::test_run_darkling_dict_rules -q`
- `pytest tests/test_gpu_sidecar.py::test_run_hashcat -q`
- `pytest tests/test_gpu_sidecar.py::test_darkling_engine_selected -q`


------
https://chatgpt.com/codex/tasks/task_e_689cb4d81044832693cb99989ae88ee2