### PR TITLE
test: cover darkling rule attack paths

### DIFF
--- a/darkling/tests/test_cli.py
+++ b/darkling/tests/test_cli.py
@@ -1,0 +1,25 @@
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "attack, extra",
+    [
+        ("0", ["--mask", "?d"]),
+        ("1", []),
+        ("2", ["--ruleset", "configs/ruleset_baked256.json"]),
+        ("3", []),
+    ],
+)
+def test_darkling_cli_attacks(attack, extra):
+    """Basic smoke tests for darkling-engine CLI attack options."""
+    if shutil.which("darkling-engine") is None:
+        pytest.skip("darkling-engine not built")
+
+    darkling_dir = Path(__file__).resolve().parents[1]
+    cmd = ["darkling-engine", "--attack", attack, *extra]
+    proc = subprocess.run(cmd, cwd=darkling_dir, capture_output=True, text=True)
+    assert proc.returncode == 0

--- a/tests/test_gpu_sidecar.py
+++ b/tests/test_gpu_sidecar.py
@@ -649,7 +649,7 @@ def test_cached_wordlist_loaded(monkeypatch):
     assert not Path(wl_path).exists()
 
 
-def test_run_hashcat_ext_rules(monkeypatch, tmp_path):
+def test_execute_job_ext_rules_hashcat(monkeypatch, tmp_path):
     sidecar = gpu_sidecar.GPUSidecar("worker", {"uuid": "gpu", "index": 0}, "http://sv")
     monkeypatch.setattr(gpu_sidecar, "r", FakeRedis())
 
@@ -678,13 +678,14 @@ def test_run_hashcat_ext_rules(monkeypatch, tmp_path):
         "rules": str(rules),
     }
 
-    sidecar.run_hashcat(batch)
+    sidecar.execute_job(batch)
 
+    assert captured["cmd"][0] == "hashcat"
     assert "-r" in captured["cmd"]
     assert str(rules) in captured["cmd"]
 
 
-def test_run_darkling_dict_rules(monkeypatch, tmp_path):
+def test_execute_job_dict_rules_darkling(monkeypatch, tmp_path):
     sidecar = gpu_sidecar.GPUSidecar("worker", {"uuid": "gpu", "index": 0}, "http://sv")
     monkeypatch.setattr(gpu_sidecar, "r", FakeRedis())
 
@@ -715,8 +716,9 @@ def test_run_darkling_dict_rules(monkeypatch, tmp_path):
         "shards": json.dumps([str(wl)]),
     }
 
-    sidecar._run_engine("darkling-engine", batch)
+    sidecar.execute_job(batch)
 
+    assert captured["cmd"][0] == "darkling-engine"
     assert "--rules" in captured["cmd"]
     assert str(rules) in captured["cmd"]
     assert "--shard" in captured["cmd"]

--- a/tests/test_orchestrator_agent.py
+++ b/tests/test_orchestrator_agent.py
@@ -3,6 +3,7 @@ import sys
 
 ROOT = os.path.dirname(os.path.dirname(__file__))
 import json
+import pytest
 from utils import redis_manager
 
 import orchestrator_agent
@@ -299,7 +300,11 @@ def test_dispatch_priority_first(monkeypatch):
     assert "2" in ids
 
 
-def test_attack_mode_dict_rules(monkeypatch, tmp_path):
+@pytest.mark.parametrize(
+    "rulefile, expected",
+    [("ruleset.json", "dict_rules"), ("common.rules", "ext_rules")],
+)
+def test_attack_mode_with_rules(monkeypatch, tmp_path, rulefile, expected):
     wl = tmp_path / "wl.txt"
     wl.write_text("pass\n")
     fake = DRBase()
@@ -307,7 +312,7 @@ def test_attack_mode_dict_rules(monkeypatch, tmp_path):
     fake.store["batch:1"] = {
         "hashes": json.dumps(["h"]),
         "wordlist": str(wl),
-        "rules": "ruleset.json",
+        "rules": rulefile,
     }
     setup_common(monkeypatch, fake)
     monkeypatch.setattr(orchestrator_agent, "compute_backlog_target", lambda: 1)
@@ -319,30 +324,6 @@ def test_attack_mode_dict_rules(monkeypatch, tmp_path):
 
     stream, mapping = fake.streams[0]
     job = fake.jobs[f"job:{mapping['job_id']}"]
-    assert job["attack_mode"] == "dict_rules"
-    assert job["rules"] == "ruleset.json"
-
-
-def test_attack_mode_ext_rules(monkeypatch, tmp_path):
-    wl = tmp_path / "wl.txt"
-    wl.write_text("pass\n")
-    fake = DRBase()
-    fake.queue.append("1")
-    fake.store["batch:1"] = {
-        "hashes": json.dumps(["h"]),
-        "wordlist": str(wl),
-        "rules": "common.rules",
-    }
-    setup_common(monkeypatch, fake)
-    monkeypatch.setattr(orchestrator_agent, "compute_backlog_target", lambda: 1)
-    monkeypatch.setattr(orchestrator_agent, "pending_count", lambda *a, **k: 0)
-    monkeypatch.setattr(orchestrator_agent, "any_darkling_workers", lambda: False)
-    monkeypatch.setattr(orchestrator_agent, "cache_wordlist", lambda p: "key")
-
-    orchestrator_agent.dispatch_batches()
-
-    stream, mapping = fake.streams[0]
-    job = fake.jobs[f"job:{mapping['job_id']}"]
-    assert job["attack_mode"] == "ext_rules"
-    assert job["rules"] == "common.rules"
+    assert job["attack_mode"] == expected
+    assert job["rules"] == rulefile
 


### PR DESCRIPTION
## Summary
- ensure orchestrator sets attack mode to dict_rules vs ext_rules based on rule file
- check GPU sidecar routes dict_rules to darkling engine and ext_rules to hashcat
- add smoke tests for darkling-engine CLI attack options

## Testing
- `pytest tests/test_orchestrator_agent.py::test_attack_mode_with_rules tests/test_gpu_sidecar.py::test_execute_job_ext_rules_hashcat tests/test_gpu_sidecar.py::test_execute_job_dict_rules_darkling darkling/tests/test_cli.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689cb95a115c83269d0be5f54933c223