### PR TITLE
Fix FastAPI test stub for lifespan arg

### DIFF
--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -47,7 +47,7 @@ class BaseModel:
 
 # FastAPI stub
 fastapi_stub = types.ModuleType("fastapi")
-fastapi_stub.FastAPI = lambda: FakeApp()
+fastapi_stub.FastAPI = lambda *a, **kw: FakeApp()
 fastapi_stub.UploadFile = object
 fastapi_stub.File = lambda *a, **kw: None
 fastapi_stub.WebSocket = object


### PR DESCRIPTION
## Summary
- allow FastAPI stub to accept arbitrary parameters so tests using lifespan argument succeed

## Testing
- `pytest tests/test_server_get_batch.py tests/test_orchestrator_agent.py tests/test_gpu_sidecar.py tests/test_worker_agent.py`


------
https://chatgpt.com/codex/tasks/task_e_689cbea6ce108326b0cd3d3fc5479f3f